### PR TITLE
feat: 일기 좋아요 기능 구현

### DIFF
--- a/Application-Module/src/main/java/com/canvas/application/like/exception/LikeException.java
+++ b/Application-Module/src/main/java/com/canvas/application/like/exception/LikeException.java
@@ -1,0 +1,31 @@
+package com.canvas.application.like.exception;
+
+import com.canvas.common.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class LikeException extends BusinessException {
+
+    private static final String CODE_PREFIX = "Like";
+    private static final String DEFAULT_MESSAGE = "좋아요 예외가 발생했습니다.";
+    private static final HttpStatus DEFAULT_HTTP_STATUS = HttpStatus.BAD_REQUEST;
+
+    public LikeException() {
+        super(CODE_PREFIX, 0, DEFAULT_HTTP_STATUS, DEFAULT_MESSAGE);
+    }
+
+    public LikeException(String codePrefix, int errorCode, HttpStatus httpStatus, String message) {
+        super(codePrefix, errorCode, httpStatus, message);
+    }
+
+    public static class LikeNotFoundException extends LikeException {
+        public LikeNotFoundException() {
+            super(CODE_PREFIX, 1, HttpStatus.NOT_FOUND, "좋아요 기록을 찾을 수 없습니다.");
+        }
+    }
+
+    public static class LikeAlreadyExistsException extends LikeException {
+        public LikeAlreadyExistsException() {
+            super(CODE_PREFIX, 2, HttpStatus.CONFLICT, "이미 좋아요를 누른 일기입니다.");
+        }
+    }
+}

--- a/Application-Module/src/main/java/com/canvas/application/like/in/AddLikeUseCase.java
+++ b/Application-Module/src/main/java/com/canvas/application/like/in/AddLikeUseCase.java
@@ -1,0 +1,10 @@
+package com.canvas.application.like.in;
+
+public interface AddLikeUseCase {
+    void add(Command command);
+
+    record Command(
+            String userId,
+            String diaryId
+    ) {}
+}

--- a/Application-Module/src/main/java/com/canvas/application/like/in/CancelLikeUseCase.java
+++ b/Application-Module/src/main/java/com/canvas/application/like/in/CancelLikeUseCase.java
@@ -1,0 +1,10 @@
+package com.canvas.application.like.in;
+
+public interface CancelLikeUseCase {
+    void cancel(Command command);
+
+    record Command(
+            String userId,
+            String diaryId
+    ) {}
+}

--- a/Application-Module/src/main/java/com/canvas/application/like/out/LikeManagementPort.java
+++ b/Application-Module/src/main/java/com/canvas/application/like/out/LikeManagementPort.java
@@ -1,0 +1,9 @@
+package com.canvas.application.like.out;
+
+import com.canvas.domain.common.DomainId;
+import com.canvas.domain.diary.entity.Like;
+
+public interface LikeManagementPort {
+    void add(Like like);
+    void remove(DomainId userId, DomainId diaryId);
+}

--- a/Application-Module/src/main/java/com/canvas/application/like/service/LikeCommandService.java
+++ b/Application-Module/src/main/java/com/canvas/application/like/service/LikeCommandService.java
@@ -1,0 +1,37 @@
+package com.canvas.application.like.service;
+
+import com.canvas.application.like.in.AddLikeUseCase;
+import com.canvas.application.like.in.CancelLikeUseCase;
+import com.canvas.application.like.out.LikeManagementPort;
+import com.canvas.domain.common.DomainId;
+import com.canvas.domain.diary.entity.Like;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class LikeCommandService implements AddLikeUseCase, CancelLikeUseCase {
+
+    private final LikeManagementPort likeManagementPort;
+
+    @Override
+    public void add(AddLikeUseCase.Command command) {
+        likeManagementPort.add(
+                new Like(
+                        DomainId.generate(),
+                        DomainId.from(command.userId()),
+                        DomainId.from(command.diaryId())
+                )
+        );
+    }
+
+    @Override
+    public void cancel(CancelLikeUseCase.Command command) {
+        likeManagementPort.remove(
+                DomainId.from(command.userId()),
+                DomainId.from(command.diaryId())
+        );
+    }
+}

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/adapter/LikeManagementJpaAdapter.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/adapter/LikeManagementJpaAdapter.java
@@ -1,0 +1,36 @@
+package com.canvas.persistence.jpa.diary.adapter;
+
+import com.canvas.application.like.exception.LikeException;
+import com.canvas.application.like.out.LikeManagementPort;
+import com.canvas.domain.common.DomainId;
+import com.canvas.domain.diary.entity.Like;
+import com.canvas.persistence.jpa.diary.LikeMapper;
+import com.canvas.persistence.jpa.diary.repository.LikeJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class LikeManagementJpaAdapter implements LikeManagementPort {
+
+    private final LikeJpaRepository likeJpaRepository;
+
+    @Override
+    public void add(Like like) {
+        if (likeJpaRepository.existsByUserIdAndDiaryId(like.getUserId().value(), like.getDiaryId().value())) {
+            throw new LikeException.LikeAlreadyExistsException();
+        }
+
+        likeJpaRepository.save(LikeMapper.toEntity(like));
+    }
+
+    @Override
+    public void remove(DomainId userId, DomainId diaryId) {
+        if (!likeJpaRepository.existsByUserIdAndDiaryId(userId.value(), diaryId.value())) {
+            throw new LikeException.LikeNotFoundException();
+        }
+
+        likeJpaRepository.deleteByUserIdAndDiaryId(userId.value(), diaryId.value());
+    }
+
+}

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/repository/LikeJpaRepository.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/repository/LikeJpaRepository.java
@@ -1,0 +1,11 @@
+package com.canvas.persistence.jpa.diary.repository;
+
+import com.canvas.persistence.jpa.diary.entity.LikeEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface LikeJpaRepository extends JpaRepository<LikeEntity, UUID> {
+    boolean existsByUserIdAndDiaryId(UUID userId, UUID diaryId);
+    void deleteByUserIdAndDiaryId(UUID userId, UUID diaryId);
+}


### PR DESCRIPTION
## 구현 내용

* [x] `LikeException` 생성
* [x] `LikeJpaRepository` 생성
* [x] `LikeManagementPort` 생성 및 `LikeManagementJpaAdapter`로 구현
* [x] `AddLikeUseCase`, `CancelLikeUseCase` 생성 및 `LikeCommandService`로 구현

## 상세 내용
### LikeException
- `LikeNotFoundException`: 좋아요 취소 요청 시 없을 경우 발생하는 예외
- `LikeAlreadyExistsException`: 좋아요 추가 요청 시 이미 있을 경우 발생하는 예외

### LikeJpaRepository
- `existsByUserIdAndDidaryId`: `userId`, `diaryId`가 일치하는 `LikeEntity`가 존재하는지 여부 반환
- `deleteByUserIdAndDiaryId`: `userId`, `diaryId`가 일치하는 `LikeEntity` 삭제

### LikeManagamentJpaAdapter
- `add`: 좋아요 정보를 DB에 추가한다. 이미 좋아요가 있으면 `LikeAlreadyExistsException`이 발생한다.
- `remove`: 좋아요 정보를 DB에서 삭제한다. 없다면 `LikeNotFoundException`이 발생한다.

### LikeCommandService
- `add`: 좋아요 추가 로직
- `cancel`: 좋아요 취소 로직

## 고민한 내용
### HTTP 상태 코드
- `LikeAlreadyExistsException`의 HTTP 상태 코드를 400 Bad Request와 409 Conflict 중 무엇으로 해야 하는지
- 400 Bad Request는 클라이언트의 요청이 잘못되었음을 나타낸다.
- 409 Conflict는 요청과 서버의 상태가 충돌했음을 나타낸다. 요청 처리 중 비지니스 로직상 불가능하거나 모순이 생긴 경우 사용한다.
- 참고한 글
  - [중복된 값을 저장하려고 할 때 HTTP 응답코드로 무엇을 반환해야할까?](https://geumba.tistory.com/78) 
  - [https://inpa.tistory.com/entry/HTTP-🌐-4XX-Client-Error-상태-코드-제대로-알아보기#📍_409_상태코드_흐름_예시](https://inpa.tistory.com/entry/HTTP-%F0%9F%8C%90-4XX-Client-Error-%EC%83%81%ED%83%9C-%EC%BD%94%EB%93%9C-%EC%A0%9C%EB%8C%80%EB%A1%9C-%EC%95%8C%EC%95%84%EB%B3%B4%EA%B8%B0#%F0%9F%93%8D_409_%EC%83%81%ED%83%9C%EC%BD%94%EB%93%9C_%ED%9D%90%EB%A6%84_%EC%98%88%EC%8B%9C) 

## 개선할 내용
- 테스트 코드 작성

