### PR TITLE
feat: 내 앨범 조회 기능 추가

### DIFF
--- a/Application-Module/src/main/java/com/canvas/application/diary/port/in/GetAlbumDiaryUseCase.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/port/in/GetAlbumDiaryUseCase.java
@@ -1,0 +1,43 @@
+package com.canvas.application.diary.port.in;
+
+import java.util.List;
+
+public interface GetAlbumDiaryUseCase {
+    Response getAlbum(Query.Recent query);
+    Response getAlbumByContent(Query.Content query);
+    Response getAlbumByEmotion(Query.Emotion query);
+
+    class Query {
+        public record Recent(
+            String userId,
+            Integer page,
+            Integer size
+        ) {}
+
+        public record Content(
+                String userId,
+                String content,
+                Integer page,
+                Integer size
+        ) {}
+
+        public record Emotion(
+                String userId,
+                String emotion,
+                Integer page,
+                Integer size
+        ) {}
+    }
+
+    record Response(
+            List<DiaryInfo> diaries,
+            Integer size,
+            Integer number,
+            Boolean hasNext
+    ) {
+        public record DiaryInfo(
+                String diaryId,
+                String mainImageUrl
+        ) {}
+    }
+}

--- a/Application-Module/src/main/java/com/canvas/application/diary/port/in/GetDiaryUseCase.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/port/in/GetDiaryUseCase.java
@@ -6,11 +6,11 @@ import java.time.LocalDate;
 import java.util.List;
 
 public interface GetDiaryUseCase {
-    Response.Diary getMyDiary(Command.Diary command);
-    Response.Diary getOtherDiary(Command.Diary command);
-    Response.HomeCalendar getHomeCalendar(Command.HomeCalendar command);
+    Response.Diary getMyDiary(Query.Diary query);
+    Response.Diary getOtherDiary(Query.Diary query);
+    Response.HomeCalendar getHomeCalendar(Query.HomeCalendar query);
 
-    class Command {
+    class Query {
         public record Diary(
                 String userId,
                 String diaryId

--- a/Application-Module/src/main/java/com/canvas/application/diary/port/out/DiaryManagementPort.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/port/out/DiaryManagementPort.java
@@ -1,7 +1,10 @@
 package com.canvas.application.diary.port.out;
 
+import com.canvas.common.page.PageRequest;
+import com.canvas.common.page.Slice;
 import com.canvas.domain.common.DomainId;
 import com.canvas.domain.diary.entity.Diary;
+import com.canvas.domain.diary.enums.Emotion;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -12,5 +15,8 @@ public interface DiaryManagementPort {
     Diary getByIdAndWriterId(DomainId diaryId, DomainId writerId);
     boolean existsByIdAndWriterId(DomainId diaryId, DomainId writerId);
     List<Diary> getByUserIdAndMonth(DomainId userId, LocalDate date);
+    Slice<Diary> getAlbum(PageRequest pageRequest, DomainId userId);
+    Slice<Diary> getAlbumByContent(PageRequest pageRequest, DomainId userId, String content);
+    Slice<Diary> getAlbumByEmotion(PageRequest pageRequest, DomainId userId, Emotion emotion);
     void deleteById(DomainId diaryId);
 }

--- a/Application-Module/src/main/java/com/canvas/application/diary/service/DiaryQueryService.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/service/DiaryQueryService.java
@@ -18,32 +18,32 @@ public class DiaryQueryService implements GetDiaryUseCase {
     private final DiaryManagementPort diaryManagementPort;
 
     @Override
-    public Response.Diary getMyDiary(Command.Diary command) {
+    public GetDiaryUseCase.Response.Diary getMyDiary(GetDiaryUseCase.Query.Diary query) {
         Diary diary = diaryManagementPort.getByIdAndWriterId(
-                DomainId.from(command.diaryId()),
-                DomainId.from(command.userId())
+                DomainId.from(query.diaryId()),
+                DomainId.from(query.userId())
         );
 
-        return toResponseDiary(command.userId(), diary);
+        return toResponseDiary(query.userId(), diary);
     }
 
     @Override
-    public Response.Diary getOtherDiary(Command.Diary command) {
-        Diary diary = diaryManagementPort.getPublicById(DomainId.from(command.diaryId()));
+    public GetDiaryUseCase.Response.Diary getOtherDiary(GetDiaryUseCase.Query.Diary query) {
+        Diary diary = diaryManagementPort.getPublicById(DomainId.from(query.diaryId()));
 
-        return toResponseDiary(command.userId(), diary);
+        return toResponseDiary(query.userId(), diary);
     }
 
     @Override
-    public Response.HomeCalendar getHomeCalendar(Command.HomeCalendar command) {
+    public GetDiaryUseCase.Response.HomeCalendar getHomeCalendar(GetDiaryUseCase.Query.HomeCalendar query) {
         List<Diary> diaries = diaryManagementPort.getByUserIdAndMonth(
-                DomainId.from(command.userId()),
-                command.date()
+                DomainId.from(query.userId()),
+                query.date()
         );
 
-        return new Response.HomeCalendar(
+        return new GetDiaryUseCase.Response.HomeCalendar(
                 diaries.stream()
-                        .map(diary -> new Response.HomeCalendar.Diary(
+                        .map(diary -> new GetDiaryUseCase.Response.HomeCalendar.Diary(
                                 diary.getId().toString(),
                                 diary.getDateTime().toLocalDate(),
                                 diary.getDiaryContent().getEmotion()
@@ -51,8 +51,8 @@ public class DiaryQueryService implements GetDiaryUseCase {
         );
     }
 
-    private static Response.Diary toResponseDiary(String userId, Diary diary) {
-        return new Response.Diary(
+    private static GetDiaryUseCase.Response.Diary toResponseDiary(String userId, Diary diary) {
+        return new GetDiaryUseCase.Response.Diary(
                 diary.getId().toString(),
                 diary.getDiaryContent().getContent(),
                 diary.getDiaryContent().getEmotion(),
@@ -60,7 +60,7 @@ public class DiaryQueryService implements GetDiaryUseCase {
                 diary.getLikes().stream()
                         .anyMatch(like -> like.getUserId().equals(DomainId.from(userId))),
                 diary.getDiaryContent().getImages().stream()
-                        .map(image -> new Response.Diary.Image(
+                        .map(image -> new GetDiaryUseCase.Response.Diary.Image(
                                 image.getId().toString(),
                                 image.getIsMain(),
                                 image.getS3Uri()

--- a/Common-Module/src/main/java/com/canvas/common/page/PageRequest.java
+++ b/Common-Module/src/main/java/com/canvas/common/page/PageRequest.java
@@ -1,0 +1,8 @@
+package com.canvas.common.page;
+
+public record PageRequest(
+        Integer page,
+        Integer size,
+        Sort sort
+) {
+}

--- a/Common-Module/src/main/java/com/canvas/common/page/Slice.java
+++ b/Common-Module/src/main/java/com/canvas/common/page/Slice.java
@@ -1,0 +1,19 @@
+package com.canvas.common.page;
+
+import java.util.List;
+
+public record Slice<T>(
+        List<T> content,
+        Integer size,
+        Integer number,
+        Boolean hasNext
+) {
+    public static <T> Slice<T> of(
+            List<T> content,
+            Integer size,
+            Integer number,
+            Boolean hasNext
+    ) {
+        return new Slice<>(content, size, number, hasNext);
+    }
+}

--- a/Common-Module/src/main/java/com/canvas/common/page/SliceResponse.java
+++ b/Common-Module/src/main/java/com/canvas/common/page/SliceResponse.java
@@ -1,0 +1,11 @@
+package com.canvas.common.page;
+
+import java.util.List;
+
+public record SliceResponse<T>(
+        List<T> content,
+        Integer size,
+        Integer number,
+        Boolean hasNext
+) {
+}

--- a/Common-Module/src/main/java/com/canvas/common/page/Sort.java
+++ b/Common-Module/src/main/java/com/canvas/common/page/Sort.java
@@ -1,0 +1,29 @@
+package com.canvas.common.page;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public record Sort(
+        List<Order> orders
+) {
+
+    public static Sort by(Direction direction, String property) {
+        return new Sort(List.of(new Order(direction, property)));
+    }
+
+    public Sort and(Sort sort) {
+        List<Order> newOrders = new ArrayList<>(orders);
+        newOrders.addAll(sort.orders);
+
+        return new Sort(newOrders);
+    }
+
+    public record Order(
+            Direction direction,
+            String property
+    ) { }
+
+    public enum Direction {
+        ASC, DESC
+    }
+}

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/common/PageMapper.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/common/PageMapper.java
@@ -1,0 +1,37 @@
+package com.canvas.persistence.jpa.common;
+
+
+import com.canvas.common.page.PageRequest;
+import com.canvas.common.page.Slice;
+import com.canvas.common.page.Sort;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.domain.Sort.Order;
+
+import java.util.function.Function;
+
+import static org.springframework.data.domain.PageRequest.of;
+import static org.springframework.data.domain.Sort.by;
+
+public class PageMapper {
+    public static org.springframework.data.domain.PageRequest toJpaPageRequest(PageRequest pageRequest) {
+        return of(pageRequest.page(), pageRequest.size(), toJpaSort(pageRequest.sort()));
+    }
+
+    private static org.springframework.data.domain.Sort toJpaSort(Sort sort) {
+        return by(sort.orders().stream()
+                        .map(order -> new Order(
+                                Direction.valueOf(order.direction().name()),
+                                order.property()))
+                        .toList());
+    }
+
+    public static <T, S> Slice<T> toDomainSlice(org.springframework.data.domain.Slice<S> slice, Function<S, T> toDomain) {
+        var mappedSlice = slice.map(toDomain);
+        return Slice.of(
+                mappedSlice.getContent(),
+                mappedSlice.getSize(),
+                mappedSlice.getNumber(),
+                mappedSlice.hasNext()
+        );
+    }
+}

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/adapter/DiaryManagementJpaAdapter.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/adapter/DiaryManagementJpaAdapter.java
@@ -2,8 +2,12 @@ package com.canvas.persistence.jpa.diary.adapter;
 
 import com.canvas.application.diary.exception.DiaryException;
 import com.canvas.application.diary.port.out.DiaryManagementPort;
+import com.canvas.common.page.PageRequest;
+import com.canvas.common.page.Slice;
 import com.canvas.domain.common.DomainId;
 import com.canvas.domain.diary.entity.Diary;
+import com.canvas.domain.diary.enums.Emotion;
+import com.canvas.persistence.jpa.common.PageMapper;
 import com.canvas.persistence.jpa.diary.DiaryMapper;
 import com.canvas.persistence.jpa.diary.entity.DiaryEntity;
 import com.canvas.persistence.jpa.diary.repository.DiaryJpaRepository;
@@ -55,6 +59,38 @@ public class DiaryManagementJpaAdapter implements DiaryManagementPort {
         return diaryJpaRepository.findByWriterIdAndCreatedAtBetween(userId.value(), start, end).stream()
                 .map(DiaryMapper::toDomain)
                 .toList();
+    }
+
+    @Override
+    public Slice<Diary> getAlbum(PageRequest pageRequest, DomainId userId) {
+        var diaryEntities = diaryJpaRepository.findByWriterId(
+                PageMapper.toJpaPageRequest(pageRequest),
+                userId.value()
+        );
+
+        return PageMapper.toDomainSlice(diaryEntities, DiaryMapper::toDomain);
+    }
+
+    @Override
+    public Slice<Diary> getAlbumByContent(PageRequest pageRequest, DomainId userId, String content) {
+        var diaryEntities = diaryJpaRepository.findByWriterIdAndContentContains(
+                PageMapper.toJpaPageRequest(pageRequest),
+                userId.value(),
+                content
+        );
+
+        return PageMapper.toDomainSlice(diaryEntities, DiaryMapper::toDomain);
+    }
+
+    @Override
+    public Slice<Diary> getAlbumByEmotion(PageRequest pageRequest, DomainId userId, Emotion emotion) {
+        var diaryEntities = diaryJpaRepository.findByWriterIdAndEmotion(
+                PageMapper.toJpaPageRequest(pageRequest),
+                userId.value(),
+                emotion.name()
+        );
+
+        return PageMapper.toDomainSlice(diaryEntities, DiaryMapper::toDomain);
     }
 
     @Override

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/repository/DiaryJpaRepository.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/repository/DiaryJpaRepository.java
@@ -1,6 +1,8 @@
 package com.canvas.persistence.jpa.diary.repository;
 
 import com.canvas.persistence.jpa.diary.entity.DiaryEntity;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -33,6 +35,30 @@ public interface DiaryJpaRepository extends JpaRepository<DiaryEntity, UUID> {
         where d.writerId = :writerId and d.createdAt between :start and :end
     """)
     List<DiaryEntity> findByWriterIdAndCreatedAtBetween(UUID writerId, LocalDateTime start, LocalDateTime end);
+
+    @Query("""
+        select d
+        from DiaryEntity d
+        left join fetch d.likeEntities
+        where d.writerId = :writerId
+    """)
+    Slice<DiaryEntity> findByWriterId(Pageable pageable, UUID writerId);
+
+    @Query("""
+        select d
+        from DiaryEntity d
+        left join fetch d.likeEntities
+        where d.writerId = :writerId and d.content like %:content%
+    """)
+    Slice<DiaryEntity> findByWriterIdAndContentContains(Pageable pageable, UUID writerId, String content);
+
+    @Query("""
+        select d
+        from DiaryEntity d
+        left join fetch d.likeEntities
+        where d.writerId = :writerId and d.emotion = :emotion
+    """)
+    Slice<DiaryEntity> findByWriterIdAndEmotion(Pageable pageable, UUID writerId, String emotion);
 
     boolean existsByIdAndWriterId(UUID diaryId, UUID writerId);
 }

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/repository/DiaryJpaRepository.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/repository/DiaryJpaRepository.java
@@ -36,28 +36,8 @@ public interface DiaryJpaRepository extends JpaRepository<DiaryEntity, UUID> {
     """)
     List<DiaryEntity> findByWriterIdAndCreatedAtBetween(UUID writerId, LocalDateTime start, LocalDateTime end);
 
-    @Query("""
-        select d
-        from DiaryEntity d
-        left join fetch d.likeEntities
-        where d.writerId = :writerId
-    """)
     Slice<DiaryEntity> findByWriterId(Pageable pageable, UUID writerId);
-
-    @Query("""
-        select d
-        from DiaryEntity d
-        left join fetch d.likeEntities
-        where d.writerId = :writerId and d.content like %:content%
-    """)
     Slice<DiaryEntity> findByWriterIdAndContentContains(Pageable pageable, UUID writerId, String content);
-
-    @Query("""
-        select d
-        from DiaryEntity d
-        left join fetch d.likeEntities
-        where d.writerId = :writerId and d.emotion = :emotion
-    """)
     Slice<DiaryEntity> findByWriterIdAndEmotion(Pageable pageable, UUID writerId, String emotion);
 
     boolean existsByIdAndWriterId(UUID diaryId, UUID writerId);


### PR DESCRIPTION
# 구현 내용
* [x]  `PageRequest`, `Slice`, `Sort`, `SliceResponse`, `PageMapper` 생성
* [x] `DiaryManagementPort` 내 메소드 생성 및 `DiaryManagementJpaAdapter`에 구현
* [x] `GetAlbumDiaryUseCase` 생성 및 `DiaryQueryService`로 구현

# 상세 내용
### PageRequest
```java
public record PageRequest(
        Integer page,
        Integer size,
        Sort sort
) {
}
```
- JPA의 `Pageable`에 대응하는 도메인 계층 클래스
- `page`: `size` 기준 조회할 페이지 번호
- `size`: 한 페이지 내의 데이터 수
- `sort`: 정렬 기준

### Slice
```java
public record Slice<T>(
        List<T> content,
        Integer size,
        Integer number,
        Boolean hasNext
) {
}
```
- JPA의 `Slice`에 대응하는 도메인 계층 클래스
- `content`: 슬라이스에 포함된 데이터
- `size`: 슬라이스 크기
- `number`: 현재 슬라이스 번호
- `hasNext`: 다음 슬라이스가 존재하는지 여부

### Sort
```java
public record Sort(
        List<Order> orders
) {

    public static Sort by(Direction direction, String property) {
        return new Sort(List.of(new Order(direction, property)));
    }

    public Sort and(Sort sort) {
        List<Order> newOrders = new ArrayList<>(orders);
        newOrders.addAll(sort.orders);

        return new Sort(newOrders);
    }

    public record Order(
            Direction direction,
            String property
    ) { }

    public enum Direction {
        ASC, DESC
    }
}
```
- JPA의 `Sort`에 대응하는 도메인 계층 클래스
- `Order` 리스트로 구성된다.
  - `Direction`: `ASC` | `DESC`
  - `property`: 정렬 기준이 되는 요소 이름

### SliceResponse
- Bootstrap 계층에서 응답으로 사용할 클래스

### PageMapper
```java
public class PageMapper {
    public static org.springframework.data.domain.PageRequest toJpaPageRequest(PageRequest pageRequest) {
        return of(pageRequest.page(), pageRequest.size(), toJpaSort(pageRequest.sort()));
    }

    private static org.springframework.data.domain.Sort toJpaSort(Sort sort) {
        return by(sort.orders().stream()
                        .map(order -> new Order(
                                Direction.valueOf(order.direction().name()),
                                order.property()))
                        .toList());
    }

    public static <T, S> Slice<T> toDomainSlice(org.springframework.data.domain.Slice<S> slice, Function<S, T> toDomain) {
        var mappedSlice = slice.map(toDomain);
        return Slice.of(
                mappedSlice.getContent(),
                mappedSlice.getSize(),
                mappedSlice.getNumber(),
                mappedSlice.hasNext()
        );
    }
}
```
- `toJpaPageRequest`: 도메인 `pageRequest`를 JPA의 `pageRequest`로 변환한다.
- `toJpaSort`: 도메인 `Sort`를 JPA의 `Sort`로 변환한다.
- `toDomainSlice`: JPA `Slice`의 content를 도메인 클래스로 변환한 다음 도메인 `Slice`로 바꾼다.

### DiaryManagementJpaAdapter
```java
    @Override
    public Slice<Diary> getAlbum(PageRequest pageRequest, DomainId userId) {
        var diaryEntities = diaryJpaRepository.findByWriterId(
                PageMapper.toJpaPageRequest(pageRequest),
                userId.value()
        );

        return PageMapper.toDomainSlice(diaryEntities, DiaryMapper::toDomain);
    }

    @Override
    public Slice<Diary> getAlbumByContent(PageRequest pageRequest, DomainId userId, String content) {
        var diaryEntities = diaryJpaRepository.findByWriterIdAndContentContains(
                PageMapper.toJpaPageRequest(pageRequest),
                userId.value(),
                content
        );

        return PageMapper.toDomainSlice(diaryEntities, DiaryMapper::toDomain);
    }

    @Override
    public Slice<Diary> getAlbumByEmotion(PageRequest pageRequest, DomainId userId, Emotion emotion) {
        var diaryEntities = diaryJpaRepository.findByWriterIdAndEmotion(
                PageMapper.toJpaPageRequest(pageRequest),
                userId.value(),
                emotion.name()
        );

        return PageMapper.toDomainSlice(diaryEntities, DiaryMapper::toDomain);
    }
```
- `getAlbum`: 일기 슬라이스를 `pageRequest` 조건에 맞게 반환한다.
- `getAlbumByContent`: 일기 내용에 `content`를 포함하는 일기 슬라이스를 `pageRequest` 조건에 맞게 반환한다.
- `getAlbumByEmotion`: 일기 감정이 `emotion`인 일기 슬라이스를 `pageRequest` 조건에 맞게 반환한다.

### DiaryQueryService
```java
    @Override
    public GetAlbumDiaryUseCase.Response getAlbum(GetAlbumDiaryUseCase.Query.Recent query) {
        Slice<Diary> slice = diaryManagementPort.getAlbum(
                new PageRequest(query.page(), query.size(), Sort.by(Sort.Direction.DESC, "createdAt")),
                DomainId.from(query.userId())
        );

        return toResponseAlbum(slice);
    }

    @Override
    public GetAlbumDiaryUseCase.Response getAlbumByContent(GetAlbumDiaryUseCase.Query.Content query) {
        Slice<Diary> slice = diaryManagementPort.getAlbumByContent(
                new PageRequest(query.page(), query.size(), Sort.by(Sort.Direction.DESC, "createdAt")),
                DomainId.from(query.userId()),
                query.content()
        );

        return toResponseAlbum(slice);
    }

    @Override
    public GetAlbumDiaryUseCase.Response getAlbumByEmotion(GetAlbumDiaryUseCase.Query.Emotion query) {
        Slice<Diary> slice = diaryManagementPort.getAlbumByEmotion(
                new PageRequest(query.page(), query.size(), Sort.by(Sort.Direction.DESC, "createdAt")),
                DomainId.from(query.userId()),
                Emotion.parse(query.emotion())
        );

        return toResponseAlbum(slice);
    }

    private static GetAlbumDiaryUseCase.Response toResponseAlbum(Slice<Diary> slice) {
        return new GetAlbumDiaryUseCase.Response(
                slice.content().stream()
                        .map(diary -> new GetAlbumDiaryUseCase.Response.DiaryInfo(
                                diary.getId().toString(),
                                diary.getDiaryContent().getImages().stream()
                                        .filter(Image::getIsMain)
                                        .map(Image::getS3Uri)
                                        .findFirst()
                                        .orElse(DEFAULT_IMAGE_URL)))
                        .toList(),
                slice.size(),
                slice.number(),
                slice.hasNext()
        );
    }
```
```java
    record Response(
            List<DiaryInfo> diaries,
            Integer size,
            Integer number,
            Boolean hasNext
    ) {
        public record DiaryInfo(
                String diaryId,
                String mainImageUrl
        ) {}
    }
```
- `getAlbum`: 최신순 앨범 슬라이스를 반환한다.
- `getAlbumByContent`: 지정한 내용을 포함하는 최신순 앨범 슬라이스를 반환한다.
- `getAlbumByEmotion`: 지정한 감정인 최신순 앨범 슬라이스를 반환한다.
- `toResponseAlbum`: `Slice<Diary>`를 `Response`로 변환한다. `Diary`의 모든 정보가 아닌 `diaryId`, `mainImageUrl`만을 반환한다. `isMain`이 `true`인 `Image`가 없으면 `DEFAULT_IMAGE_URL` 값을 가진다.

# 고민한 내용
- `Slice`, `Sort` 등의 클래스를 어느 모듈에 두어야 하는지?
  - 페이징은 직접적인 비즈니스 로직과는 관련이 적어 보임.
  - 하지만 인프라 계층에서 조회한 페이징 객체가 계층을 건널 때마다 DTO가 필요하다.
  - 일단은 공통 계층 모듈에 두었지만 나중에 각 계층에 두는 것으로 수정해야겠다.

# 참고한 내용
- [Spring Pageable](https://velog.io/@soluinoon/Spring-Pageable-%ED%8C%8C%ED%97%A4%EC%B9%98%EA%B8%B0)
- [[Spring Data JPA] 효율적인 페이지네이션을 위한 Pageable, Slice 분석](https://wimoney.tistory.com/entry/SpringDataJPA-%ED%9A%A8%EC%9C%A8%EC%A0%81%EC%9D%B8-%ED%8E%98%EC%9D%B4%EC%A7%95%EC%9D%84-%EC%9C%84%ED%95%9C-Pageable-Slice-%EB%B6%84%EC%84%9D)

# 개선할 내용
- 테스트 코드 작성

