### PR TITLE
feat: 일기 api 추가, @RequestParam을 Enum 타입으로 받도록 Converter 생성

### DIFF
--- a/Application-Module/src/main/java/com/canvas/application/diary/exception/DiaryException.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/exception/DiaryException.java
@@ -29,4 +29,7 @@ public class DiaryException extends BusinessException {
         }
     }
 
+    public static class DiaryBadRequestException extends DiaryException {
+        public DiaryBadRequestException() {super(3, HttpStatus.BAD_REQUEST, "유효하지 않은 일기 요청입니다.");}
+    }
 }

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/api/DiaryApi.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/api/DiaryApi.java
@@ -1,6 +1,9 @@
 package com.canvas.bootstrap.diary.api;
 
+import com.canvas.application.common.enums.Style;
 import com.canvas.bootstrap.diary.dto.*;
+import com.canvas.bootstrap.diary.enums.ExploreOrder;
+import com.canvas.bootstrap.diary.enums.SearchType;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -87,4 +90,43 @@ public interface DiaryApi {
     })
     void deleteDiary(@PathVariable String diaryId);
 
+    @Operation(summary = "일기 검색")
+    @GetMapping("/search")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "일기 검색 성공",
+                    content = {
+                            @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = DiarySearchResponse.class)
+                            )
+                    }
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "쿼리 스트링 오류"
+            )
+    })
+    DiarySearchResponse searchDiary(@RequestParam SearchType type, @RequestParam Style value);
+
+    @Operation(summary = "상대방 일기 탐색")
+    @GetMapping("/explore")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "일기 탐색 성공",
+                    content = {
+                            @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = DiaryExploreResponse.class)
+                            )
+                    }
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "쿼리 스트링 오류"
+            )
+    })
+    DiaryExploreResponse exploreDiary(@RequestParam ExploreOrder order);
 }

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/controller/DiaryController.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/controller/DiaryController.java
@@ -1,25 +1,30 @@
 package com.canvas.bootstrap.diary.controller;
 
+import com.canvas.application.diary.port.in.AddDiaryUseCase;
+import com.canvas.application.diary.port.in.GetDiaryUseCase;
+import com.canvas.application.diary.port.in.ModifyDiaryUseCase;
+import com.canvas.application.diary.port.in.RemoveDiaryUseCase;
 import com.canvas.bootstrap.diary.api.DiaryApi;
 import com.canvas.bootstrap.diary.dto.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDate;
 
 @RestController
-@RequestMapping("/api/v1/diaries")
 @RequiredArgsConstructor
 public class DiaryController implements DiaryApi {
 
-//    private final AddDiaryUseCase addDiaryUseCase;
-//    private final GetDiaryUseCase getDiaryUseCase;
-//    private final ModifyDiaryUseCase modifyDiaryUseCase;
-//    private final RemoveDiaryUseCase removeDiaryUseCase;
+    private final AddDiaryUseCase addDiaryUseCase;
+    private final GetDiaryUseCase getDiaryUseCase;
+    private final ModifyDiaryUseCase modifyDiaryUseCase;
+    private final RemoveDiaryUseCase removeDiaryUseCase;
 
     @Override
-    @PostMapping()
     public CreateDiaryResponse createDiary(CreateDiaryRequest request) {
 
 //        AddDiaryUseCase.Response response = addDiaryUseCase.add(AddDiaryUseCase.Command());
@@ -28,26 +33,22 @@ public class DiaryController implements DiaryApi {
     }
 
     @Override
-    @GetMapping("/{diaryId}")
     public ReadDiaryResponse readDiary(String diaryId) {
 
         return null;
     }
 
     @Override
-    @GetMapping()
     public ReadDiaryCalenderResponse readDiaryCalender(@RequestParam @DateTimeFormat(pattern = "yyyy-MM") LocalDate date) {
         return null;
     }
 
     @Override
-    @PatchMapping("/{diaryId}")
     public void updateDiary(@PathVariable String diaryId, @RequestBody UpdateDiaryRequest request) {
 
     }
 
     @Override
-    @DeleteMapping("/{diaryId}")
     public void deleteDiary(@PathVariable String diaryId) {
 
     }

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/controller/DiaryController.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/controller/DiaryController.java
@@ -1,11 +1,14 @@
 package com.canvas.bootstrap.diary.controller;
 
+import com.canvas.application.common.enums.Style;
 import com.canvas.application.diary.port.in.AddDiaryUseCase;
 import com.canvas.application.diary.port.in.GetDiaryUseCase;
 import com.canvas.application.diary.port.in.ModifyDiaryUseCase;
 import com.canvas.application.diary.port.in.RemoveDiaryUseCase;
 import com.canvas.bootstrap.diary.api.DiaryApi;
 import com.canvas.bootstrap.diary.dto.*;
+import com.canvas.bootstrap.diary.enums.ExploreOrder;
+import com.canvas.bootstrap.diary.enums.SearchType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -47,5 +50,15 @@ public class DiaryController implements DiaryApi {
     @Override
     public void deleteDiary(String diaryId) {
 
+    }
+
+    @Override
+    public DiarySearchResponse searchDiary(SearchType type, Style value) {
+        return null;
+    }
+
+    @Override
+    public DiaryExploreResponse exploreDiary(ExploreOrder order) {
+        return null;
     }
 }

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/controller/DiaryController.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/controller/DiaryController.java
@@ -7,10 +7,6 @@ import com.canvas.application.diary.port.in.RemoveDiaryUseCase;
 import com.canvas.bootstrap.diary.api.DiaryApi;
 import com.canvas.bootstrap.diary.dto.*;
 import lombok.RequiredArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDate;
@@ -39,17 +35,17 @@ public class DiaryController implements DiaryApi {
     }
 
     @Override
-    public ReadDiaryCalenderResponse readDiaryCalender(@RequestParam @DateTimeFormat(pattern = "yyyy-MM") LocalDate date) {
+    public ReadDiaryCalenderResponse readDiaryCalender(LocalDate date) {
         return null;
     }
 
     @Override
-    public void updateDiary(@PathVariable String diaryId, @RequestBody UpdateDiaryRequest request) {
+    public void updateDiary(String diaryId, UpdateDiaryRequest request) {
 
     }
 
     @Override
-    public void deleteDiary(@PathVariable String diaryId) {
+    public void deleteDiary(String diaryId) {
 
     }
 }

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/converter/StringToExploreOrderConverter.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/converter/StringToExploreOrderConverter.java
@@ -1,0 +1,13 @@
+package com.canvas.bootstrap.diary.converter;
+
+import com.canvas.bootstrap.diary.enums.ExploreOrder;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StringToExploreOrderConverter implements Converter<String, ExploreOrder> {
+    @Override
+    public ExploreOrder convert(String source) {
+        return ExploreOrder.parse(source);
+    }
+}

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/converter/StringToSearchTypeConverter.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/converter/StringToSearchTypeConverter.java
@@ -1,0 +1,13 @@
+package com.canvas.bootstrap.diary.converter;
+
+import com.canvas.bootstrap.diary.enums.SearchType;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StringToSearchTypeConverter implements Converter<String, SearchType> {
+    @Override
+    public SearchType convert(String source) {
+        return SearchType.parse(source);
+    }
+}

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/converter/StringToStyleConverter.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/converter/StringToStyleConverter.java
@@ -1,0 +1,13 @@
+package com.canvas.bootstrap.diary.converter;
+
+import com.canvas.application.common.enums.Style;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StringToStyleConverter implements Converter<String, Style> {
+    @Override
+    public Style convert(String source) {
+        return Style.parse(source);
+    }
+}

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/DiaryExploreResponse.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/DiaryExploreResponse.java
@@ -1,0 +1,13 @@
+package com.canvas.bootstrap.diary.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "상대방 일기 탐색 응답")
+public record DiaryExploreResponse(
+
+    @Schema(description = "일기 썸내일 정보 리스트 반환")
+    List<DiaryThumbnail> diaries
+
+) {}

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/DiarySearchResponse.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/DiarySearchResponse.java
@@ -1,0 +1,13 @@
+package com.canvas.bootstrap.diary.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "앨범에서 일기 검색에 대한 응답")
+public record DiarySearchResponse(
+
+    @Schema(description = "일기 썸내일 정보 리스트 반환")
+    List<DiaryThumbnail> diaries
+
+) { }

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/DiaryThumbnail.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/DiaryThumbnail.java
@@ -1,0 +1,12 @@
+package com.canvas.bootstrap.diary.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "일기 썸네일 정보")
+public record DiaryThumbnail(
+        @Schema(description = "일기 ID")
+        String diaryId,
+        @Schema(description = "일기 메인 이미지 url")
+        String mainImageUrl
+) {}
+

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/enums/ExploreOrder.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/enums/ExploreOrder.java
@@ -1,0 +1,24 @@
+package com.canvas.bootstrap.diary.enums;
+
+import com.canvas.application.diary.exception.DiaryException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+@RequiredArgsConstructor
+@Getter
+public enum ExploreOrder {
+    LATEST("latest"),
+    POPULARITY("popularity"),
+    LIKED_DATE("likedDate");
+
+    private final String value;
+
+    public static ExploreOrder parse(String value) {
+        return Arrays.stream(ExploreOrder.values())
+                .filter(order -> order.getValue().equals(value))
+                .findFirst()
+                .orElseThrow(DiaryException.DiaryBadRequestException::new);
+    }
+}

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/enums/SearchType.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/enums/SearchType.java
@@ -1,0 +1,23 @@
+package com.canvas.bootstrap.diary.enums;
+
+import com.canvas.application.diary.exception.DiaryException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+@RequiredArgsConstructor
+@Getter
+public enum SearchType {
+    TAG("tag"),
+    CONTENT("content");
+
+    private final String value;
+
+    public static SearchType parse(String value) {
+        return Arrays.stream(SearchType.values())
+                .filter(searchType -> searchType.getValue().equals(value))
+                .findFirst()
+                .orElseThrow(DiaryException.DiaryBadRequestException::new);
+    }
+}

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/image/api/ImageApi.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/image/api/ImageApi.java
@@ -1,0 +1,44 @@
+package com.canvas.bootstrap.image.api;
+
+import com.canvas.bootstrap.image.dto.CreateImageRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Image", description = "Image API")
+@RequestMapping("/api/v1/diaries/{diaryId}/images")
+public interface ImageApi {
+
+    @Operation(summary = "이미지 생성")
+    @PostMapping()
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "이미지 생성 성공"
+            )
+    })
+    void createImage(@PathVariable String diaryId, @RequestBody CreateImageRequest createImageRequest);
+
+    @Operation(summary = "이미지 삭제")
+    @DeleteMapping("/{imageId}")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "이미지 삭제 성공"
+            )
+    })
+    void deleteImage(@PathVariable String diaryId, @PathVariable String imageId);
+
+    @Operation(summary = "일기 대표 이미지 수정")
+    @PatchMapping("/{imageId}")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "일기 대표 이미지 수정 성공"
+            )
+    })
+    void updateMainImage(@PathVariable String diaryId, @PathVariable String imageId);
+
+}

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/image/controllor/ImageController.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/image/controllor/ImageController.java
@@ -1,0 +1,23 @@
+package com.canvas.bootstrap.image.controllor;
+
+import com.canvas.bootstrap.image.api.ImageApi;
+import com.canvas.bootstrap.image.dto.CreateImageRequest;
+
+public class ImageController implements ImageApi {
+
+
+    @Override
+    public void createImage(String diaryId, CreateImageRequest createImageRequest) {
+
+    }
+
+    @Override
+    public void deleteImage(String diaryId, String imageId) {
+
+    }
+
+    @Override
+    public void updateMainImage(String diaryId, String imageId) {
+
+    }
+}

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/image/dto/CreateImageRequest.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/image/dto/CreateImageRequest.java
@@ -1,0 +1,10 @@
+package com.canvas.bootstrap.image.dto;
+
+import com.canvas.application.common.enums.Style;
+
+public record CreateImageRequest(
+        String diaryId,
+        String content,
+        Style style
+) {
+}

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/image/dto/CreateImageRequest.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/image/dto/CreateImageRequest.java
@@ -1,10 +1,15 @@
 package com.canvas.bootstrap.image.dto;
 
 import com.canvas.application.common.enums.Style;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "이미지 추가 요청")
 public record CreateImageRequest(
+        @Schema(description = "일기 ID")
         String diaryId,
+        @Schema(description = "일기 내용")
         String content,
+        @Schema(description = "일기 화풍")
         Style style
 ) {
 }

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/like/api/LikeApi.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/like/api/LikeApi.java
@@ -1,0 +1,33 @@
+package com.canvas.bootstrap.like.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequestMapping("/api/v1/{diaryId}/like")
+public interface LikeApi {
+
+    @Operation(summary = "일기 좋아요 추가")
+    @PostMapping()
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "좋아요 추가 성공"
+            )
+    })
+    void addLike(@PathVariable String diaryId);
+
+    @Operation(summary = "일기 좋아요 삭제")
+    @DeleteMapping()
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "좋아요 삭제 성공"
+            )
+    })
+    void deleteLike(@PathVariable String diaryId);
+}

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/like/controller/LikeController.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/like/controller/LikeController.java
@@ -1,0 +1,17 @@
+package com.canvas.bootstrap.like.controller;
+
+import com.canvas.bootstrap.like.api.LikeApi;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class LikeController implements LikeApi {
+    @Override
+    public void addLike(String diaryId) {
+
+    }
+
+    @Override
+    public void deleteLike(String diaryId) {
+
+    }
+}


### PR DESCRIPTION
# 구현 내용
- [x] like api 추가
- [x] 탐색, 검색 api 추가
- [x] 이미지 api 추가
- [x] 일기 탐색, 검색 시 필요한 Enum 타입 추가
- [x] 일기 요청 시 잘못된 쿼리 스트링 요청 시 예외 추가

# 고민 내용

## 이미지 생성
- 노션에 이미지 생성 api에서 반환값이 없던데 imageId와 imageurl 반환 안해줘도 됨?

## Conveter 추가
- `@RequestParam`에서 Enum 타입 받을 수 있도록 Converter 추가해서 사용하였다.
- 나는 Enum 타입으로 `@RequestParam` 받는 것이 좋은 것 같아서 converter 추가해서 사용하였는데 괜찮을까?
- converter package를 따로 만들어서 관리하도록 하였다.

## DiaryException 추가
- converter에서 적절한 enum 값 찾을 때 존재하지 않으면 `DiaryException`을 던지도록 하였다.
- 여기서 400에러(BAD_REQUEST) 던지도록 예외 추가하였다.
- Converter를 추가하면서 현재 Style.parse에서 존재하지 않으면 `IllegalArgumentException` 예외를 던지도록 되어 있는데 이것도BAD_REQUEST로 변경하면 좋을 것 같다.

## dto
- `DiaryExploreResponse`, `DiarySearchResponse`에서 같은 diaryId와 mianImageUrl을 가진 JSON 형식을 List로 던지는데 
- `DiaryThumbnail` record를 따로 만들어서 사용하도록 하였음.

## 패키지 분리
- 이미지와 좋아요 부분은 따로 패키지를 분리해서 controller를 나눠서 처리하였고, 탐색, 검색 부분은 그냥 일기 부분에 추가하였다.





