### PR TITLE
feat: AccessUser Annotation 추가

### DIFF
--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/common/annotation/AccessUser.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/common/annotation/AccessUser.java
@@ -1,0 +1,14 @@
+package com.canvas.bootstrap.common.annotation;
+
+import io.swagger.v3.oas.annotations.Parameter;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Parameter(hidden = true)
+public @interface AccessUser {
+}

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/common/annotation/AccessUserArgumentResolver.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/common/annotation/AccessUserArgumentResolver.java
@@ -1,0 +1,22 @@
+package com.canvas.bootstrap.common.annotation;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class AccessUserArgumentResolver implements HandlerMethodArgumentResolver {
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(AccessUser.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) throws Exception {
+        return "0192c9ce-6703-75e9-bd6c-4d3fea6537ed";
+    }
+}

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/common/config/WebConfig.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/common/config/WebConfig.java
@@ -1,0 +1,17 @@
+package com.canvas.bootstrap.common.config;
+
+
+import com.canvas.bootstrap.common.annotation.AccessUserArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new AccessUserArgumentResolver());
+    }
+}


### PR DESCRIPTION
## 구현 내용

* [x] `AccessUser` 생성
* [x] `AccessUserArgumentResolver` 생성 및 등록

## 상세 내용
### AccessUser
- 메소드 파라미터에 붙일 수 있는 annotation

### AccessUserArgumentResolver
- `@AccessUser`를 붙인 파라미터에 `userId` 값을 부여한다.
- 현재는 디버깅 목적으로 특정 값을 반환한도록 만들었다.

### WebConfig
- `AccessUserArgumentResolver`를 등록한다.

## 개선할 내용
- 추후 JWT, 세션과 연동 필요

