### PR TITLE
refactor: 코드 리팩토링

### DIFF
--- a/Application-Module/src/main/java/com/canvas/application/diary/service/DiaryQueryService.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/service/DiaryQueryService.java
@@ -1,14 +1,13 @@
 package com.canvas.application.diary.service;
 
-import com.canvas.application.diary.port.in.GetDiaryUseCase;
 import com.canvas.application.diary.port.in.GetAlbumDiaryUseCase;
+import com.canvas.application.diary.port.in.GetDiaryUseCase;
 import com.canvas.application.diary.port.out.DiaryManagementPort;
 import com.canvas.common.page.PageRequest;
 import com.canvas.common.page.Slice;
 import com.canvas.common.page.Sort;
 import com.canvas.domain.common.DomainId;
 import com.canvas.domain.diary.entity.Diary;
-import com.canvas.domain.diary.entity.Image;
 import com.canvas.domain.diary.enums.Emotion;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,8 +19,6 @@ import java.util.List;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class DiaryQueryService implements GetDiaryUseCase, GetAlbumDiaryUseCase {
-
-    private static final String DEFAULT_IMAGE_URL = "https://canvas-diary.s3.ap-northeast-2.amazonaws.com/sample.jpg";
 
     private final DiaryManagementPort diaryManagementPort;
 
@@ -71,7 +68,7 @@ public class DiaryQueryService implements GetDiaryUseCase, GetAlbumDiaryUseCase 
                         .map(image -> new GetDiaryUseCase.Response.Diary.Image(
                                 image.getId().toString(),
                                 image.getIsMain(),
-                                image.getS3Uri()
+                                image.getImageUrl()
                         )).toList()
         );
     }
@@ -113,11 +110,7 @@ public class DiaryQueryService implements GetDiaryUseCase, GetAlbumDiaryUseCase 
                 slice.content().stream()
                         .map(diary -> new GetAlbumDiaryUseCase.Response.DiaryInfo(
                                 diary.getId().toString(),
-                                diary.getDiaryContent().getImages().stream()
-                                        .filter(Image::getIsMain)
-                                        .map(Image::getS3Uri)
-                                        .findFirst()
-                                        .orElse(DEFAULT_IMAGE_URL)))
+                                diary.getMainImageOrDefault()))
                         .toList(),
                 slice.size(),
                 slice.number(),

--- a/Application-Module/src/main/java/com/canvas/application/image/port/in/AddImageUseCase.java
+++ b/Application-Module/src/main/java/com/canvas/application/image/port/in/AddImageUseCase.java
@@ -3,13 +3,17 @@ package com.canvas.application.image.port.in;
 import com.canvas.application.common.enums.Style;
 
 public interface AddImageUseCase {
-    void add(Command command);
+    Response add(Command command);
 
     record Command(
-            String userId,
             String diaryId,
             String content,
             Style style
-    ) {
-    }
+    ) {}
+
+    record Response(
+            String imageId,
+            Boolean isMain,
+            String imageUrl
+    ) {}
 }

--- a/Application-Module/src/main/java/com/canvas/application/image/port/service/ImageCommandService.java
+++ b/Application-Module/src/main/java/com/canvas/application/image/port/service/ImageCommandService.java
@@ -28,14 +28,16 @@ public class ImageCommandService
     private final ImageUploadPort imageUploadPort;
 
     @Override
-    public void add(AddImageUseCase.Command command) {
+    public Response add(AddImageUseCase.Command command) {
         String prompt = imagePromptGeneratePort.generatePrompt(command.content());
-        String imageUrl = imageGenerationPort.generate(prompt, command.style());
-        String s3Url = imageUploadPort.upload(imageUrl);
+        String generatedImageUrl = imageGenerationPort.generate(prompt, command.style());
+        String uploadedImageUrl = imageUploadPort.upload(generatedImageUrl);
 
-        Image image = new Image(DomainId.generate(), DomainId.from(command.diaryId()), true, s3Url);
+        Image image = Image.create(DomainId.generate(), DomainId.from(command.diaryId()), true, uploadedImageUrl);
 
         imageManagementPort.save(image);
+
+        return new Response(image.getId().toString(), image.getIsMain(), image.getImageUrl());
     }
 
     @Override

--- a/Application-Module/src/main/java/com/canvas/application/like/service/LikeCommandService.java
+++ b/Application-Module/src/main/java/com/canvas/application/like/service/LikeCommandService.java
@@ -19,7 +19,7 @@ public class LikeCommandService implements AddLikeUseCase, CancelLikeUseCase {
     @Override
     public void add(AddLikeUseCase.Command command) {
         likeManagementPort.add(
-                new Like(
+                Like.create(
                         DomainId.generate(),
                         DomainId.from(command.userId()),
                         DomainId.from(command.diaryId())

--- a/Domain-Module/src/main/java/com/canvas/domain/diary/entity/Diary.java
+++ b/Domain-Module/src/main/java/com/canvas/domain/diary/entity/Diary.java
@@ -2,12 +2,15 @@ package com.canvas.domain.diary.entity;
 
 import com.canvas.domain.common.DomainId;
 import com.canvas.domain.diary.vo.DiaryContent;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public class Diary {
     private DomainId id;
@@ -15,23 +18,14 @@ public class Diary {
     private DiaryContent diaryContent;
     private LocalDateTime dateTime;
     private Boolean isPublic;
-    private List<Like> likes = new ArrayList<>();
+    private List<Like> likes;
 
-    public Diary(DomainId id, DomainId writerId, DiaryContent diaryContent, LocalDateTime dateTime, Boolean isPublic, List<Like> likes) {
-        this.id = id;
-        this.writerId = writerId;
-        this.diaryContent = diaryContent;
-        this.dateTime = dateTime;
-        this.isPublic = isPublic;
-        this.likes.addAll(likes);
+    public static Diary create(DomainId id, DomainId writerId, DiaryContent diaryContent, LocalDateTime dateTime, Boolean isPublic, List<Like> likes) {
+        return new Diary(id, writerId, diaryContent, dateTime, isPublic, likes);
     }
 
-    public Diary(DomainId id, DomainId writerId, DiaryContent diaryContent, LocalDateTime dateTime, Boolean isPublic) {
-        this.id = id;
-        this.writerId = writerId;
-        this.diaryContent = diaryContent;
-        this.dateTime = dateTime;
-        this.isPublic = isPublic;
+    public static Diary create(DomainId id, DomainId writerId, DiaryContent diaryContent, LocalDateTime dateTime, Boolean isPublic) {
+        return new Diary(id, writerId, diaryContent, dateTime, isPublic, new ArrayList<>());
     }
 
     public void addLike(Like like) {
@@ -44,5 +38,9 @@ public class Diary {
 
     public void updatePublic(Boolean isPublic) {
         this.isPublic = isPublic;
+    }
+
+    public String getMainImageOrDefault() {
+        return this.diaryContent.getMainImageOrDefault();
     }
 }

--- a/Domain-Module/src/main/java/com/canvas/domain/diary/entity/Image.java
+++ b/Domain-Module/src/main/java/com/canvas/domain/diary/entity/Image.java
@@ -10,9 +10,19 @@ public class Image {
     private DomainId id;
     private DomainId diaryId;
     private Boolean isMain;
-    private String s3Uri;
+    private String imageUrl;
+
+    public static final String DEFAULT_IMAGE_URL = "https://canvas-diary.s3.ap-northeast-2.amazonaws.com/sample.jpg";
+
+    public static Image create(DomainId id, DomainId diaryId, Boolean isMain, String imageUrl) {
+        return new Image(id, diaryId, isMain, imageUrl);
+    }
 
     public void updateMain(Boolean isMain) {
         this.isMain = isMain;
+    }
+
+    public Boolean isMain(){
+        return this.isMain;
     }
 }

--- a/Domain-Module/src/main/java/com/canvas/domain/diary/entity/Like.java
+++ b/Domain-Module/src/main/java/com/canvas/domain/diary/entity/Like.java
@@ -1,13 +1,18 @@
 package com.canvas.domain.diary.entity;
 
 import com.canvas.domain.common.DomainId;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public class Like {
     private DomainId id;
     private DomainId userId;
     private DomainId diaryId;
+
+    public static Like create(DomainId id, DomainId userId, DomainId diaryId) {
+        return new Like(id, userId, diaryId);
+    }
 }

--- a/Domain-Module/src/main/java/com/canvas/domain/diary/vo/DiaryContent.java
+++ b/Domain-Module/src/main/java/com/canvas/domain/diary/vo/DiaryContent.java
@@ -2,24 +2,32 @@ package com.canvas.domain.diary.vo;
 
 import com.canvas.domain.diary.entity.Image;
 import com.canvas.domain.diary.enums.Emotion;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-import java.util.ArrayList;
 import java.util.List;
 
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public class DiaryContent {
     private String content;
     private Emotion emotion;
-    private List<Image> images = new ArrayList<>();
+    private List<Image> images;
 
-    public DiaryContent(String content, Emotion emotion, List<Image> images) {
-        this.content = content;
-        this.emotion = emotion;
-        this.images.addAll(images);
+    public static DiaryContent create(String content, Emotion emotion, List<Image> images) {
+        return new DiaryContent(content, emotion, images);
     }
 
     public void addImage(Image image) {
         this.images.add(image);
+    }
+
+    public String getMainImageOrDefault(){
+        return images.stream()
+                .filter(Image::isMain)
+                .map(Image::getImageUrl)
+                .findFirst()
+                .orElse(Image.DEFAULT_IMAGE_URL);
     }
 }

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/DiaryMapper.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/DiaryMapper.java
@@ -23,10 +23,10 @@ public class DiaryMapper {
     }
 
     public static Diary toDomain(DiaryEntity diaryEntity) {
-        return new Diary(
-                new DomainId(diaryEntity.getId()),
-                new DomainId(diaryEntity.getWriterId()),
-                new DiaryContent(
+        return Diary.create(
+                DomainId.from(diaryEntity.getId()),
+                DomainId.from(diaryEntity.getWriterId()),
+                DiaryContent.create(
                         diaryEntity.getContent(),
                         Emotion.parse(diaryEntity.getEmotion()),
                         diaryEntity.getImageEntities().stream()

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/ImageMapper.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/ImageMapper.java
@@ -12,7 +12,7 @@ public class ImageMapper {
         return new ImageEntity(
                 image.getId().value(),
                 image.getIsMain(),
-                image.getS3Uri(),
+                image.getImageUrl(),
                 image.getDiaryId().value()
         );
     }
@@ -24,11 +24,11 @@ public class ImageMapper {
     }
 
     public static Image toDomain(ImageEntity imageEntity) {
-        return new Image(
+        return Image.create(
                 new DomainId(imageEntity.getId()),
                 new DomainId(imageEntity.getDiaryId()),
                 imageEntity.getIsMain(),
-                imageEntity.getS3Uri()
+                imageEntity.getImageUrl()
         );
     }
 

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/LikeMapper.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/LikeMapper.java
@@ -23,7 +23,7 @@ public class LikeMapper {
     }
 
     public static Like toDomain(LikeEntity likeEntity) {
-        return new Like(
+        return Like.create(
                 new DomainId(likeEntity.getId()),
                 new DomainId(likeEntity.getUserId()),
                 new DomainId(likeEntity.getDiaryId())

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/entity/ImageEntity.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/entity/ImageEntity.java
@@ -17,7 +17,7 @@ public class ImageEntity {
     private UUID id;
 
     private Boolean isMain;
-    private String s3Uri;
+    private String imageUrl;
 
     @Column(name = "diary_id", nullable = false)
     private UUID diaryId;
@@ -26,10 +26,10 @@ public class ImageEntity {
     @JoinColumn(name = "diary_id", insertable = false, updatable = false)
     private DiaryEntity diaryEntity;
 
-    public ImageEntity(UUID id, Boolean isMain, String s3Uri, UUID diaryId) {
+    public ImageEntity(UUID id, Boolean isMain, String imageUrl, UUID diaryId) {
         this.id = id;
         this.isMain = isMain;
-        this.s3Uri = s3Uri;
+        this.imageUrl = imageUrl;
         this.diaryId = diaryId;
     }
 


### PR DESCRIPTION
## 구현 내용

* [x] `Diary`, `Image`, `Like` 생성자 대신 정적 팩토리 메소드 사용
* [x] 디폴트 URL 지정 로직 `DiaryQueryService`에서 `Image`로 이동
* [x] `s3Url` 필드 `imageUrl`로 수정 
* [x] 이미지 생성 시 중복되는 코드 제거
* [x] `AddImageUseCase` `Response` 레코드 생성

# 상세 내용
## 정적 팩토리 메소드 사용
- 도메인 정적 팩토리 메소드 `create` 생성
- `Service`나 `Mapper`에서 생성자 대신 사용

## 디폴트 URL 지정 로직 이동
- 비즈니스 로직을 도메인으로 이동하여 코드 응집도를 높임

## 필드 이름 수정
- 인프라에 의존적이던 이름 수정

## 이미지 생성 시 중복 코드 제거
- 기존 `DiaryCommandService`와 `ImageCommandService`에서 이미지를 생성하는 코드가 중복
- `DiaryCommandService`에서 `ImageCommandService`의 인터페이스 `AddImageUseCase`의 `add` 메소드를 호출하게 하여 중복 코드를 제거
- 값을 가져다 쓸 수 있도록 `Response` 레코드 생성