### PR TITLE
fix: 버그 수정

### DIFF
--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/common/annotation/AccessUserArgumentResolver.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/common/annotation/AccessUserArgumentResolver.java
@@ -17,6 +17,6 @@ public class AccessUserArgumentResolver implements HandlerMethodArgumentResolver
                                   ModelAndViewContainer mavContainer,
                                   NativeWebRequest webRequest,
                                   WebDataBinderFactory binderFactory) throws Exception {
-        return "0192c9ce-6703-75e9-bd6c-4d3fea6537ed";
+        return "01JB8ZBQ43RSYXQ08GGH13WXZG";
     }
 }


### PR DESCRIPTION
## 구현 내용
* [x] `@AccessUser` 주입 ULID가 형식에 맞지 않았던 오류 수정
* [x] `getResult` 요청 시 쿼리 파라미터가 빠져있던 오류 수정, 요청 시기가 너무 일러 `Pending`을 응답하였던 오류 수정 

# 상세 내용
## ULID 형식 수정
- 이전 형식은 `Ulid.from()`으로 받을 수 없어 하이픈을 제거한 형식으로 변경

## FluxClient
```java
.uri(uriBuilder -> uriBuilder.path("/get_result")
                        .queryParam("id", id)
                        .build())
```
- `UriBuilder`로 `path`에 `queryParam`을 추가

```java
.flatMap(response -> {
    if (response.status.equals("Pending")) {
        return Mono.error(new RuntimeException("status is pending"));
    }
    return Mono.just(response);
})
.retryWhen(
        Retry.fixedDelay(3, Duration.ofSeconds(1))
                .filter(throwable -> throwable instanceof RuntimeException))
.doOnError(error -> System.err.println("최대 재시도에 도달했습니다: " + error.getMessage()))
```
- 재시도 로직 추가

# 개선할 내용
- 사용자 지정 예외로 변경이 필요
- `System.err.prinln` 호출 대신에 예외를 던지도록 변경이 필요
- API 응답 status가 정상 응답 외에도 여러 가지가 있어 각각 예외 처리가 필요
