### PR TITLE
feat: 일기 생성 엔드포인트 연결

### DIFF
--- a/Application-Module/src/main/java/com/canvas/application/diary/service/DiaryCommandService.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/service/DiaryCommandService.java
@@ -63,17 +63,15 @@ public class DiaryCommandService
     }
 
     private DiaryContent createDiaryContent(DomainId diaryId, String content, Style style) {
-        AddImageUseCase.Response ImageInform = addImageUseCase.add(new AddImageUseCase.Command(diaryId.toString(), content, style));
-        Image image = Image.create(
-                DomainId.from(ImageInform.imageId()),
-                diaryId,
-                ImageInform.isMain(),
-                ImageInform.imageUrl()
-        );
+        String imageUrl = addImageUseCase.create(new AddImageUseCase.Command(diaryId.toString(), content, style)).imageUrl();
 
         Emotion emotion = diaryEmotionExtractPort.emotionExtract(content);
 
-        return DiaryContent.create(content, emotion, new ArrayList<>(List.of(image)));
+        return DiaryContent.create(
+                content,
+                emotion,
+                new ArrayList<>(List.of(Image.create(DomainId.generate(), diaryId, true, imageUrl)))
+        );
     }
 
     @Override

--- a/Application-Module/src/main/java/com/canvas/application/image/port/in/AddImageUseCase.java
+++ b/Application-Module/src/main/java/com/canvas/application/image/port/in/AddImageUseCase.java
@@ -3,17 +3,26 @@ package com.canvas.application.image.port.in;
 import com.canvas.application.common.enums.Style;
 
 public interface AddImageUseCase {
-    Response add(Command command);
+    Response.add add(Command command);
+    Response.create create(Command command);
 
     record Command(
             String diaryId,
             String content,
             Style style
-    ) {}
+    ) {
+    }
 
-    record Response(
-            String imageId,
-            Boolean isMain,
-            String imageUrl
-    ) {}
+    class Response {
+        public record add(
+                String imageId,
+                Boolean isMain,
+                String imageUrl
+        ) {
+        }
+
+        public record create(
+                String imageUrl
+        ) {}
+    }
 }

--- a/Application-Module/src/main/java/com/canvas/application/image/port/service/ImageCommandService.java
+++ b/Application-Module/src/main/java/com/canvas/application/image/port/service/ImageCommandService.java
@@ -28,16 +28,22 @@ public class ImageCommandService
     private final ImageUploadPort imageUploadPort;
 
     @Override
-    public Response add(AddImageUseCase.Command command) {
+    public Response.add add(AddImageUseCase.Command command) {
+        Response.create create = create(command);
+        Image image = Image.create(DomainId.generate(), DomainId.from(command.diaryId()), true, create.imageUrl());
+
+        imageManagementPort.save(image);
+
+        return new Response.add(image.getId().toString(), image.getIsMain(), image.getImageUrl());
+    }
+
+    @Override
+    public Response.create create(AddImageUseCase.Command command) {
         String prompt = imagePromptGeneratePort.generatePrompt(command.content());
         String generatedImageUrl = imageGenerationPort.generate(prompt, command.style());
         String uploadedImageUrl = imageUploadPort.upload(generatedImageUrl);
 
-        Image image = Image.create(DomainId.generate(), DomainId.from(command.diaryId()), true, uploadedImageUrl);
-
-        imageManagementPort.save(image);
-
-        return new Response(image.getId().toString(), image.getIsMain(), image.getImageUrl());
+        return new Response.create(uploadedImageUrl);
     }
 
     @Override

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/common/annotation/AccessUserArgumentResolver.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/common/annotation/AccessUserArgumentResolver.java
@@ -17,6 +17,6 @@ public class AccessUserArgumentResolver implements HandlerMethodArgumentResolver
                                   ModelAndViewContainer mavContainer,
                                   NativeWebRequest webRequest,
                                   WebDataBinderFactory binderFactory) throws Exception {
-        return "01JB8ZBQ43RSYXQ08GGH13WXZG";
+        return "0192c9ce-6703-75e9-bd6c-4d3fea6537ed";
     }
 }

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/api/DiaryApi.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/api/DiaryApi.java
@@ -1,6 +1,7 @@
 package com.canvas.bootstrap.diary.api;
 
 import com.canvas.application.common.enums.Style;
+import com.canvas.bootstrap.common.annotation.AccessUser;
 import com.canvas.bootstrap.diary.dto.*;
 import com.canvas.bootstrap.diary.enums.ExploreOrder;
 import com.canvas.bootstrap.diary.enums.SearchType;
@@ -33,7 +34,7 @@ public interface DiaryApi {
                     }
             )
     })
-    CreateDiaryResponse createDiary(@RequestBody CreateDiaryRequest createDiaryRequest);
+    CreateDiaryResponse createDiary(@AccessUser String userId, @RequestBody CreateDiaryRequest createDiaryRequest);
 
 
     @Operation(summary = "일기 단건 조회")

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/controller/DiaryController.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/controller/DiaryController.java
@@ -24,11 +24,17 @@ public class DiaryController implements DiaryApi {
     private final RemoveDiaryUseCase removeDiaryUseCase;
 
     @Override
-    public CreateDiaryResponse createDiary(CreateDiaryRequest request) {
-
-//        AddDiaryUseCase.Response response = addDiaryUseCase.add(AddDiaryUseCase.Command());
-//        return new CreateDiaryResponse(response.diaryId());
-        return null;
+    public CreateDiaryResponse createDiary(String userId, CreateDiaryRequest request) {
+        AddDiaryUseCase.Response response = addDiaryUseCase.add(
+                new AddDiaryUseCase.Command(
+                        userId,
+                        request.date(),
+                        request.content(),
+                        request.style(),
+                        request.isPublic()
+                )
+        );
+        return new CreateDiaryResponse(response.diaryId());
     }
 
     @Override

--- a/Domain-Module/src/main/java/com/canvas/domain/common/DomainId.java
+++ b/Domain-Module/src/main/java/com/canvas/domain/common/DomainId.java
@@ -1,6 +1,5 @@
 package com.canvas.domain.common;
 
-import com.github.f4b6a3.ulid.Ulid;
 import com.github.f4b6a3.ulid.UlidCreator;
 
 import java.util.Objects;
@@ -14,7 +13,7 @@ public record DomainId(
     }
 
     public static DomainId from(String id) {
-        return new DomainId(Ulid.from(id).toUuid());
+        return new DomainId(UUID.fromString(id));
     }
 
     public static DomainId from(UUID uuid) {

--- a/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/DiaryContentConvertGeminiAdapter.java
+++ b/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/DiaryContentConvertGeminiAdapter.java
@@ -6,8 +6,10 @@ import com.canvas.domain.diary.enums.Emotion;
 import com.canvas.google.gemini.service.GeminiPromptConsts;
 import com.canvas.google.gemini.service.GeminiService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class DiaryContentConvertGeminiAdapter
@@ -17,7 +19,8 @@ public class DiaryContentConvertGeminiAdapter
 
     @Override
     public Emotion emotionExtract(String content) {
-        String emotion = geminiService.generate(GeminiPromptConsts.EMOTION_EXTRACT);
+        String emotion = geminiService.generate(GeminiPromptConsts.EMOTION_EXTRACT + content);
+        log.info("emotion={}", emotion);
         return Emotion.parse(emotion);
     }
 

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/entity/DiaryEntity.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/entity/DiaryEntity.java
@@ -20,6 +20,7 @@ public class DiaryEntity extends BaseEntity {
     @Id
     private UUID id;
 
+    @Column(length = 1_500)
     private String content;
     private String emotion;
     private Boolean isPublic;


### PR DESCRIPTION
# 구현 내용
* [x] 일기 생성 엔드포인트 연결
* [x] 이미지 생성, 저장 로직 분리 
* [x] Flux에서 생성된 이미지 URL을 읽을 수 없던 버그 수정
* [x] 감정 추출에서 일기 내용이 누락되었던 버그 수정
* [x] DB에 일기 내용을 255자 초과 저장할 수 없었던 버그 수정
* [x] `@AccessUser` 대입값이 UUID 형식이 아닌 ULID였던 버그 수정

# 상세 내용

## 이미지 생성, 저장 로직 분리
- 일기 생성, 이미지 추가 시 중복되는 코드가 중복
### ImageCommandService
```java
@Override
public Response.add add(AddImageUseCase.Command command) {
    Response.create create = create(command);
    Image image = Image.create(DomainId.generate(), DomainId.from(command.diaryId()), true, create.imageUrl());

    imageManagementPort.save(image);

    return new Response.add(image.getId().toString(), image.getIsMain(), image.getImageUrl());
}

@Override
public Response.create create(AddImageUseCase.Command command) {
    String prompt = imagePromptGeneratePort.generatePrompt(command.content());
    String generatedImageUrl = imageGenerationPort.generate(prompt, command.style());
    String uploadedImageUrl = imageUploadPort.upload(generatedImageUrl);

    return new Response.create(uploadedImageUrl);
}
```
- `AddImageUseCase`의 `add()` 메소드를 DB에 저장하는 `add()`와 그림을 생성해 URL을 반환하는 `create()`로 분리

### DiaryCommandService
```java
private DiaryContent createDiaryContent(DomainId diaryId, String content, Style style) {
    String imageUrl = addImageUseCase.create(new AddImageUseCase.Command(diaryId.toString(), content, style)).imageUrl();

    Emotion emotion = diaryEmotionExtractPort.emotionExtract(content);

    return DiaryContent.create(
            content,
            emotion,
            new ArrayList<>(List.of(Image.create(DomainId.generate(), diaryId, true, imageUrl)))
    );
}
```
- `DiaryCommandService`에서 `AddImageUseCase.create()` 호출

## Flux에서 생성된 이미지 URL을 읽을 수 없던 버그 수정
### ImageUploadS3Adaptor
```java
UriComponents uriComponents = UriComponentsBuilder.fromUriString(imageUrl).build(true);

Flux<DataBuffer> dataBufferFlux = webClient.get()
        .uri(uriComponents.toUri())
        .retrieve()
        .bodyToFlux(DataBuffer.class);
```
- 인코딩된 쿼리 파라미터를 디코딩해 전달

# 고민한 점
## DB의 자료형을 직접 명시해야 하는지
- `@Column(columnDefinition = "TEXT")`를 추가하면 MYSQL의 `TEXT` 자료형으로 속성이 지정되지만 `TEXT`가 없는 DBMS도 있어 특정 DBMS에 종속적
- `@Lob`, `@Column(length = xx)`를 사용해 대형 문자열을 저장할 수 있음
## VARCHAR와 TEXT 중 무엇을 사용해야 하는지
- `VARCHAR`는 인라인 페이지에 저장, `TEXT`는 외부 off 페이지에 저장
- `VARCHAR`는 캐싱이 가능하지만 `TEXT`는 불가능
- 일반적으로 `TEXT`보다 `VARCHAR`가 인덱싱에 효율적
- 일기 내용이 자주 조회되고 검색 기능 구현이 필요해 `VARCHAR` 선택

# 참고한 글
- [JPA/Hibernate에서 @Column(columnDefinition = "TEXT") 사용하지 않고 MySQL TEXT 타입 설정하기](https://limvik.github.io/posts/mysql-set-text-type-in-jpa-not-using-column-columndefinition-text/)
- [VARCHAR vs TEXT (이래서 JPA와 함께 SQL Mapper를!?)](https://velog.io/@yullivan/VARCHAR-vs-TEXT)
- [MySQL에서 VARCHAR와 TEXT의 차이](https://dkswnkk.tistory.com/714)

# 개선할 내용
- 일기 내용 조회 전용 DB를 사용하는 방법도 고려 가능