### PR TITLE
feat: Diary 도메인에 생성 시간 속성 추가

### DIFF
--- a/Domain-Module/src/main/java/com/canvas/domain/diary/entity/Diary.java
+++ b/Domain-Module/src/main/java/com/canvas/domain/diary/entity/Diary.java
@@ -16,16 +16,17 @@ public class Diary {
     private DomainId id;
     private DomainId writerId;
     private DiaryContent diaryContent;
-    private LocalDateTime dateTime;
+    private LocalDateTime dateTime;     // 일기 날짜
+    private LocalDateTime createdAt;    // 일기가 생성된 실제 시각
     private Boolean isPublic;
     private List<Like> likes;
 
-    public static Diary create(DomainId id, DomainId writerId, DiaryContent diaryContent, LocalDateTime dateTime, Boolean isPublic, List<Like> likes) {
-        return new Diary(id, writerId, diaryContent, dateTime, isPublic, likes);
+    public static Diary create(DomainId id, DomainId writerId, DiaryContent diaryContent, LocalDateTime dateTime, LocalDateTime createdAt, Boolean isPublic, List<Like> likes) {
+        return new Diary(id, writerId, diaryContent, dateTime, createdAt, isPublic, likes);
     }
 
     public static Diary create(DomainId id, DomainId writerId, DiaryContent diaryContent, LocalDateTime dateTime, Boolean isPublic) {
-        return new Diary(id, writerId, diaryContent, dateTime, isPublic, new ArrayList<>());
+        return new Diary(id, writerId, diaryContent, dateTime, null, isPublic, new ArrayList<>());
     }
 
     public void addLike(Like like) {

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/DiaryMapper.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/DiaryMapper.java
@@ -13,6 +13,7 @@ public class DiaryMapper {
                 diary.getDiaryContent().getContent(),
                 diary.getDiaryContent().getEmotion().name(),
                 diary.getIsPublic(),
+                diary.getDateTime(),
                 diary.getWriterId().value()
         );
 
@@ -31,8 +32,8 @@ public class DiaryMapper {
                         Emotion.parse(diaryEntity.getEmotion()),
                         diaryEntity.getImageEntities().stream()
                                 .map(ImageMapper::toDomain)
-                                .toList()
-                ),
+                                .toList()),
+                diaryEntity.getDateTime(),
                 diaryEntity.getCreatedAt(),
                 diaryEntity.getIsPublic(),
                 diaryEntity.getLikeEntities().stream()

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/entity/DiaryEntity.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/entity/DiaryEntity.java
@@ -7,6 +7,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -24,6 +25,7 @@ public class DiaryEntity extends BaseEntity {
     private String content;
     private String emotion;
     private Boolean isPublic;
+    private LocalDateTime dateTime;
 
     @Column(name = "writer_id", nullable = false)
     private UUID writerId;
@@ -37,11 +39,12 @@ public class DiaryEntity extends BaseEntity {
     @OneToMany(mappedBy = "diaryEntity", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<LikeEntity> likeEntities = new ArrayList<>();
 
-    public DiaryEntity(UUID id, String content, String emotion, Boolean isPublic, UUID writerId) {
+    public DiaryEntity(UUID id, String content, String emotion, Boolean isPublic, LocalDateTime dateTime, UUID writerId) {
         this.id = id;
         this.content = content;
         this.emotion = emotion;
         this.isPublic = isPublic;
+        this.dateTime = dateTime;
         this.writerId = writerId;
     }
 


### PR DESCRIPTION
# 구현 내용
* [x] 일기 날짜와 실제 작성 시각 분리

# 상세 내용
## 일기 날짜와 실제 작성 시각 분리
- 탐색 탭의 최신순 정렬에 실제 작성 시각이 필요
- 이전에는 일기를 당일에만 작성할 수 있게 구상해 필드가 하나로 충분했음