### PR TITLE
feat: 일기 조회 엔드포인트 추가

### DIFF
--- a/Application-Module/src/main/java/com/canvas/application/diary/port/in/GetDiaryUseCase.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/port/in/GetDiaryUseCase.java
@@ -3,11 +3,12 @@ package com.canvas.application.diary.port.in;
 import com.canvas.domain.diary.enums.Emotion;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface GetDiaryUseCase {
-    Response.Diary getMyDiary(Query.Diary query);
-    Response.Diary getOtherDiary(Query.Diary query);
+    Response.DiaryInfo getMyDiary(Query.Diary query);
+    Response.DiaryInfo getOtherDiary(Query.Diary query);
     Response.HomeCalendar getHomeCalendar(Query.HomeCalendar query);
 
     class Query {
@@ -23,15 +24,16 @@ public interface GetDiaryUseCase {
     }
 
     class Response {
-        public record Diary(
+        public record DiaryInfo(
                 String diaryId,
                 String content,
                 Emotion emotion,
                 Integer likeCount,
                 Boolean isLiked,
-                List<Image> images
+                LocalDateTime date,
+                List<ImageInfo> images
         ) {
-            public record Image(
+            public record ImageInfo(
                     String imageId,
                     Boolean isMain,
                     String imageUrl
@@ -39,9 +41,9 @@ public interface GetDiaryUseCase {
         }
 
         public record HomeCalendar(
-                List<Diary> diaries
+                List<DiaryInfo> diaries
         ) {
-            public record Diary(
+            public record DiaryInfo(
                     String diaryId,
                     LocalDate date,
                     Emotion emotion

--- a/Application-Module/src/main/java/com/canvas/application/diary/service/DiaryQueryService.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/service/DiaryQueryService.java
@@ -23,7 +23,7 @@ public class DiaryQueryService implements GetDiaryUseCase, GetAlbumDiaryUseCase 
     private final DiaryManagementPort diaryManagementPort;
 
     @Override
-    public GetDiaryUseCase.Response.Diary getMyDiary(GetDiaryUseCase.Query.Diary query) {
+    public GetDiaryUseCase.Response.DiaryInfo getMyDiary(GetDiaryUseCase.Query.Diary query) {
         Diary diary = diaryManagementPort.getByIdAndWriterId(
                 DomainId.from(query.diaryId()),
                 DomainId.from(query.userId())
@@ -33,7 +33,7 @@ public class DiaryQueryService implements GetDiaryUseCase, GetAlbumDiaryUseCase 
     }
 
     @Override
-    public GetDiaryUseCase.Response.Diary getOtherDiary(GetDiaryUseCase.Query.Diary query) {
+    public GetDiaryUseCase.Response.DiaryInfo getOtherDiary(GetDiaryUseCase.Query.Diary query) {
         Diary diary = diaryManagementPort.getPublicById(DomainId.from(query.diaryId()));
 
         return toResponseDiary(query.userId(), diary);
@@ -48,7 +48,7 @@ public class DiaryQueryService implements GetDiaryUseCase, GetAlbumDiaryUseCase 
 
         return new GetDiaryUseCase.Response.HomeCalendar(
                 diaries.stream()
-                        .map(diary -> new GetDiaryUseCase.Response.HomeCalendar.Diary(
+                        .map(diary -> new GetDiaryUseCase.Response.HomeCalendar.DiaryInfo(
                                 diary.getId().toString(),
                                 diary.getDateTime().toLocalDate(),
                                 diary.getDiaryContent().getEmotion()
@@ -56,16 +56,17 @@ public class DiaryQueryService implements GetDiaryUseCase, GetAlbumDiaryUseCase 
         );
     }
 
-    private static GetDiaryUseCase.Response.Diary toResponseDiary(String userId, Diary diary) {
-        return new GetDiaryUseCase.Response.Diary(
+    private static GetDiaryUseCase.Response.DiaryInfo toResponseDiary(String userId, Diary diary) {
+        return new GetDiaryUseCase.Response.DiaryInfo(
                 diary.getId().toString(),
                 diary.getDiaryContent().getContent(),
                 diary.getDiaryContent().getEmotion(),
                 diary.getLikes().size(),
                 diary.getLikes().stream()
                         .anyMatch(like -> like.getUserId().equals(DomainId.from(userId))),
+                diary.getDateTime(),
                 diary.getDiaryContent().getImages().stream()
-                        .map(image -> new GetDiaryUseCase.Response.Diary.Image(
+                        .map(image -> new GetDiaryUseCase.Response.DiaryInfo.ImageInfo(
                                 image.getId().toString(),
                                 image.getIsMain(),
                                 image.getImageUrl()

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/api/DiaryApi.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/api/DiaryApi.java
@@ -37,12 +37,12 @@ public interface DiaryApi {
     CreateDiaryResponse createDiary(@AccessUser String userId, @RequestBody CreateDiaryRequest createDiaryRequest);
 
 
-    @Operation(summary = "일기 단건 조회")
-    @GetMapping("/{diaryId}")
+    @Operation(summary = "내 일기 단건 조회")
+    @GetMapping("/{diaryId}/my")
     @ApiResponses(value = {
             @ApiResponse(
                     responseCode = "200",
-                    description = "일기 단건 조회 성공",
+                    description = "내 일기 단건 조회 성공",
                     content = {
                             @Content(
                                     mediaType = "application/json",
@@ -51,7 +51,23 @@ public interface DiaryApi {
                     }
             )
     })
-    ReadDiaryResponse readDiary(@PathVariable String diaryId);
+    ReadDiaryResponse readMyDiary(@AccessUser String userId, @PathVariable String diaryId);
+
+    @Operation(summary = "타인 일기 단건 조회")
+    @GetMapping("/{diaryId}")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "타인 일기 단건 조회 성공",
+                    content = {
+                            @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ReadDiaryResponse.class)
+                            )
+                    }
+            )
+    })
+    ReadDiaryResponse readOtherDiary(@AccessUser String userId, @PathVariable String diaryId);
 
 
     @Operation(summary = "일기 달력 조회")
@@ -68,7 +84,7 @@ public interface DiaryApi {
                     }
             )
     })
-    ReadDiaryCalenderResponse readDiaryCalender(@RequestParam @DateTimeFormat(pattern = "yyyy-MM") LocalDate date);
+    ReadDiaryCalenderResponse readDiaryCalender(@AccessUser String userId, @RequestParam @DateTimeFormat(pattern = "yyyy-MM") LocalDate date);
 
 
     @Operation(summary = "일기 내용 수정")

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/controller/DiaryController.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/controller/DiaryController.java
@@ -34,18 +34,56 @@ public class DiaryController implements DiaryApi {
                         request.isPublic()
                 )
         );
+
         return new CreateDiaryResponse(response.diaryId());
     }
 
     @Override
-    public ReadDiaryResponse readDiary(String diaryId) {
+    public ReadDiaryResponse readMyDiary(String userId, String diaryId) {
+        GetDiaryUseCase.Response.DiaryInfo response = getDiaryUseCase.getMyDiary(new GetDiaryUseCase.Query.Diary(userId, diaryId));
 
-        return null;
+        return new ReadDiaryResponse(
+                response.diaryId(),
+                response.content(),
+                response.emotion(),
+                response.likeCount(),
+                response.isLiked(),
+                response.date(),
+                response.images().stream()
+                        .map(image -> new ReadDiaryResponse.ImageInfo(image.imageId(), image.isMain(), image.imageUrl()))
+                        .toList()
+        );
     }
 
     @Override
-    public ReadDiaryCalenderResponse readDiaryCalender(LocalDate date) {
-        return null;
+    public ReadDiaryResponse readOtherDiary(String userId, String diaryId) {
+        GetDiaryUseCase.Response.DiaryInfo response = getDiaryUseCase.getOtherDiary(new GetDiaryUseCase.Query.Diary(userId, diaryId));
+
+        return new ReadDiaryResponse(
+                response.diaryId(),
+                response.content(),
+                response.emotion(),
+                response.likeCount(),
+                response.isLiked(),
+                response.date(),
+                response.images().stream()
+                        .map(image -> new ReadDiaryResponse.ImageInfo(image.imageId(), image.isMain(), image.imageUrl()))
+                        .toList()
+        );
+    }
+
+    @Override
+    public ReadDiaryCalenderResponse readDiaryCalender(String userId, LocalDate date) {
+        GetDiaryUseCase.Response.HomeCalendar response =
+                getDiaryUseCase.getHomeCalendar(new GetDiaryUseCase.Query.HomeCalendar(userId, date));
+
+        return new ReadDiaryCalenderResponse(
+                response.diaries().stream()
+                        .map(diaryInfo -> new ReadDiaryCalenderResponse.CalenderInfo(
+                                diaryInfo.diaryId(),
+                                diaryInfo.date(),
+                                diaryInfo.emotion()))
+                        .toList());
     }
 
     @Override

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/CreateDiaryRequest.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/CreateDiaryRequest.java
@@ -14,6 +14,6 @@ public record CreateDiaryRequest(
         @Schema(description = "일기 화풍")
         Style style,
         @Schema(description = "일기 공개 여부")
-        boolean isPublic) {
-
+        boolean isPublic
+) {
 }

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/CreateDiaryResponse.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/CreateDiaryResponse.java
@@ -5,6 +5,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "일기 생성 응답")
 public record CreateDiaryResponse(
         @Schema(description = "생성된 일기 ID")
-        String DiaryId
+        String diaryId
 ) {
 }

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/CreateDiaryResponse.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/CreateDiaryResponse.java
@@ -3,8 +3,8 @@ package com.canvas.bootstrap.diary.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "일기 생성 응답")
-public record CreateDiaryResponse (
+public record CreateDiaryResponse(
         @Schema(description = "생성된 일기 ID")
         String DiaryId
-){
+) {
 }

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/DiaryExploreResponse.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/DiaryExploreResponse.java
@@ -6,8 +6,7 @@ import java.util.List;
 
 @Schema(description = "상대방 일기 탐색 응답")
 public record DiaryExploreResponse(
-
-    @Schema(description = "일기 썸내일 정보 리스트 반환")
-    List<DiaryThumbnail> diaries
-
-) {}
+        @Schema(description = "일기 썸내일 정보 리스트 반환")
+        List<DiaryThumbnail> diaries
+) {
+}

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/DiarySearchResponse.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/DiarySearchResponse.java
@@ -6,8 +6,7 @@ import java.util.List;
 
 @Schema(description = "앨범에서 일기 검색에 대한 응답")
 public record DiarySearchResponse(
-
-    @Schema(description = "일기 썸내일 정보 리스트 반환")
-    List<DiaryThumbnail> diaries
-
-) { }
+        @Schema(description = "일기 썸내일 정보 리스트 반환")
+        List<DiaryThumbnail> diaries
+) {
+}

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/DiaryThumbnail.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/DiaryThumbnail.java
@@ -8,5 +8,6 @@ public record DiaryThumbnail(
         String diaryId,
         @Schema(description = "일기 메인 이미지 url")
         String mainImageUrl
-) {}
+) {
+}
 

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/ReadDiaryCalenderResponse.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/ReadDiaryCalenderResponse.java
@@ -3,7 +3,7 @@ package com.canvas.bootstrap.diary.dto;
 import com.canvas.domain.diary.enums.Emotion;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 
 @Schema(description = "달력 조회 요청")
@@ -11,16 +11,15 @@ public record ReadDiaryCalenderResponse(
         @Schema(description = "달력에 필요한 일기 정보 리스트")
         List<CalenderInfo> diaries
 ) {
-
     @Schema(description = "달력에 필요한 일기 정보")
-    record CalenderInfo(
+    public record CalenderInfo(
             @Schema(description = "일기 ID")
             String diaryId,
             @Schema(description = "일기 날짜")
-            LocalDateTime date,
+            LocalDate date,
             @Schema(description = "일기의 감정")
             Emotion emotion
-    ) {}
-
+    ) {
+    }
 }
 

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/ReadDiaryResponse.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/ReadDiaryResponse.java
@@ -15,20 +15,21 @@ public record ReadDiaryResponse(
         @Schema(description = "일기의 감정")
         Emotion emotion,
         @Schema(description = "일기 좋아요 수")
-        Long likedCount,
+        Integer likedCount,
         @Schema(description = "일기 좋아요 선택 여부")
         boolean isLiked,
-        @Schema(description = "일기 공개 여부")
-        boolean isPublic,
         @Schema(description = "일기 생성 날짜")
         LocalDateTime date,
         @Schema(description = "일기의 이미지 정보 리스트")
         List<ImageInfo> images) {
-
-        @Schema(description = "일기의 이미지 정보")
-        public record ImageInfo(
-                @Schema(description = "이미지 ID")
-                String imageId,
-                @Schema(description = "저장된 일기 이미지 url")
-                String imageUrl) { }
+    @Schema(description = "일기의 이미지 정보")
+    public record ImageInfo(
+            @Schema(description = "이미지 ID")
+            String imageId,
+            @Schema(description = "대표 이미지 여부")
+            Boolean isMain,
+            @Schema(description = "저장된 일기 이미지 url")
+            String imageUrl
+    ) {
+    }
 }

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/UpdateDiaryRequest.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/UpdateDiaryRequest.java
@@ -7,5 +7,6 @@ public record UpdateDiaryRequest(
         @Schema(description = "일기 내용")
         String content,
         @Schema(description = "일기 공개 여부")
-        boolean isPublic) {
+        boolean isPublic
+) {
 }

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/repository/DiaryJpaRepository.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/repository/DiaryJpaRepository.java
@@ -33,6 +33,7 @@ public interface DiaryJpaRepository extends JpaRepository<DiaryEntity, UUID> {
         from DiaryEntity d
         left join fetch d.likeEntities
         where d.writerId = :writerId and d.createdAt between :start and :end
+        order by d.dateTime asc
     """)
     List<DiaryEntity> findByWriterIdAndCreatedAtBetween(UUID writerId, LocalDateTime start, LocalDateTime end);
 


### PR DESCRIPTION
# 구현 내용
* [x] Application 모듈 일기 조회 DTO 날짜 필드 추가
* [x] Bootstrap 모듈 일기 조회 DTO 대표 이미지 여부 필드 추가
* [x] 도메인과 이름이 같은 DTO 이름 변경
* [x] 달력 조회 결과 정렬해 반환
* [x] 일기 조회 엔드포인트 추가

# 세부 내용
## Application 모듈 일기 조회 DTO 날짜 필드 추가
- 일기를 쓴 날짜가 누락되어 있었음

## Bootstrap 모듈 일기 조회 DTO 대표 이미지 여부 필드 추가
- API 스펙 변경으로 `isMain` 필드 추가

## 도메인과 이름이 같은 DTO 이름 변경
- `Diary`, `Image` -> `DiaryInfo`, `ImageInfo`

## 달력 조회 결과 정렬해 반환
```java
@Query("""
    select d
    from DiaryEntity d
    left join fetch d.likeEntities
    where d.writerId = :writerId and d.createdAt between :start and :end
    order by d.dateTime asc
""")
List<DiaryEntity> findByWriterIdAndCreatedAtBetween(UUID writerId, LocalDateTime start, LocalDateTime end);
```

## 일기 조회 엔드포인트 추가
### DiaryController
- `readMyDiary`: 내 일기 단건 조회
- `readOtherDiary`: 타인 일기 단건 조회
- `readDiaryCalender`: 홈 일기 달력 조회