### PR TITLE
feat: 일기 조회 DTO 분리

### DIFF
--- a/Application-Module/src/main/java/com/canvas/application/diary/port/in/GetDiaryUseCase.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/port/in/GetDiaryUseCase.java
@@ -31,6 +31,7 @@ public interface GetDiaryUseCase {
                 Integer likeCount,
                 Boolean isLiked,
                 LocalDateTime date,
+                Boolean isPublic,
                 List<ImageInfo> images
         ) {
             public record ImageInfo(

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/api/DiaryApi.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/api/DiaryApi.java
@@ -46,12 +46,12 @@ public interface DiaryApi {
                     content = {
                             @Content(
                                     mediaType = "application/json",
-                                    schema = @Schema(implementation = ReadDiaryResponse.class)
+                                    schema = @Schema(implementation = ReadMyDiaryResponse.class)
                             )
                     }
             )
     })
-    ReadDiaryResponse readMyDiary(@AccessUser String userId, @PathVariable String diaryId);
+    ReadMyDiaryResponse readMyDiary(@AccessUser String userId, @PathVariable String diaryId);
 
     @Operation(summary = "타인 일기 단건 조회")
     @GetMapping("/{diaryId}")
@@ -62,12 +62,12 @@ public interface DiaryApi {
                     content = {
                             @Content(
                                     mediaType = "application/json",
-                                    schema = @Schema(implementation = ReadDiaryResponse.class)
+                                    schema = @Schema(implementation = ReadOtherDiaryResponse.class)
                             )
                     }
             )
     })
-    ReadDiaryResponse readOtherDiary(@AccessUser String userId, @PathVariable String diaryId);
+    ReadOtherDiaryResponse readOtherDiary(@AccessUser String userId, @PathVariable String diaryId);
 
 
     @Operation(summary = "일기 달력 조회")

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/controller/DiaryController.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/controller/DiaryController.java
@@ -39,27 +39,28 @@ public class DiaryController implements DiaryApi {
     }
 
     @Override
-    public ReadDiaryResponse readMyDiary(String userId, String diaryId) {
+    public ReadMyDiaryResponse readMyDiary(String userId, String diaryId) {
         GetDiaryUseCase.Response.DiaryInfo response = getDiaryUseCase.getMyDiary(new GetDiaryUseCase.Query.Diary(userId, diaryId));
 
-        return new ReadDiaryResponse(
+        return new ReadMyDiaryResponse(
                 response.diaryId(),
                 response.content(),
                 response.emotion(),
                 response.likeCount(),
                 response.isLiked(),
                 response.date(),
+                response.isPublic(),
                 response.images().stream()
-                        .map(image -> new ReadDiaryResponse.ImageInfo(image.imageId(), image.isMain(), image.imageUrl()))
+                        .map(image -> new ReadMyDiaryResponse.ImageInfo(image.imageId(), image.isMain(), image.imageUrl()))
                         .toList()
         );
     }
 
     @Override
-    public ReadDiaryResponse readOtherDiary(String userId, String diaryId) {
+    public ReadOtherDiaryResponse readOtherDiary(String userId, String diaryId) {
         GetDiaryUseCase.Response.DiaryInfo response = getDiaryUseCase.getOtherDiary(new GetDiaryUseCase.Query.Diary(userId, diaryId));
 
-        return new ReadDiaryResponse(
+        return new ReadOtherDiaryResponse(
                 response.diaryId(),
                 response.content(),
                 response.emotion(),
@@ -67,7 +68,7 @@ public class DiaryController implements DiaryApi {
                 response.isLiked(),
                 response.date(),
                 response.images().stream()
-                        .map(image -> new ReadDiaryResponse.ImageInfo(image.imageId(), image.isMain(), image.imageUrl()))
+                        .map(image -> new ReadOtherDiaryResponse.ImageInfo(image.imageId(), image.isMain(), image.imageUrl()))
                         .toList()
         );
     }

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/ReadMyDiaryResponse.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/ReadMyDiaryResponse.java
@@ -7,7 +7,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @Schema(description = "일기 조회 반환")
-public record ReadDiaryResponse(
+public record ReadMyDiaryResponse(
         @Schema(description = "일기 ID")
         String diaryId,
         @Schema(description = "일기 내용")
@@ -17,9 +17,11 @@ public record ReadDiaryResponse(
         @Schema(description = "일기 좋아요 수")
         Integer likedCount,
         @Schema(description = "일기 좋아요 선택 여부")
-        boolean isLiked,
+        Boolean isLiked,
         @Schema(description = "일기 생성 날짜")
         LocalDateTime date,
+        @Schema(description = "일기 공개 여부")
+        Boolean isPublic,
         @Schema(description = "일기의 이미지 정보 리스트")
         List<ImageInfo> images) {
     @Schema(description = "일기의 이미지 정보")

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/ReadOtherDiaryResponse.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/ReadOtherDiaryResponse.java
@@ -1,0 +1,35 @@
+package com.canvas.bootstrap.diary.dto;
+
+import com.canvas.domain.diary.enums.Emotion;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Schema(description = "일기 조회 반환")
+public record ReadOtherDiaryResponse(
+        @Schema(description = "일기 ID")
+        String diaryId,
+        @Schema(description = "일기 내용")
+        String content,
+        @Schema(description = "일기의 감정")
+        Emotion emotion,
+        @Schema(description = "일기 좋아요 수")
+        Integer likedCount,
+        @Schema(description = "일기 좋아요 선택 여부")
+        Boolean isLiked,
+        @Schema(description = "일기 생성 날짜")
+        LocalDateTime date,
+        @Schema(description = "일기의 이미지 정보 리스트")
+        List<ImageInfo> images) {
+    @Schema(description = "일기의 이미지 정보")
+    public record ImageInfo(
+            @Schema(description = "이미지 ID")
+            String imageId,
+            @Schema(description = "대표 이미지 여부")
+            Boolean isMain,
+            @Schema(description = "저장된 일기 이미지 url")
+            String imageUrl
+    ) {
+    }
+}


### PR DESCRIPTION
# 구현 내용
* [x] 일기 조회 DTO 분리

# 세부 내용
## 일기 조회 DTO 분리
- `ReadMyDiaryResponse`, `ReadOtherDiaryResponse`로 분리
- `ReadMyDiryResponse`는 공개 여부 수정을 위해 `isPublic` 필드를 가짐