### PR TITLE
feat: CORS Allow-credentials 헤더 true로 설정

### DIFF
--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/common/config/WebConfig.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/common/config/WebConfig.java
@@ -16,7 +16,8 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addMapping("/**")
                 .allowedOrigins("http://localhost:5173", "http://www.canvas-diary.kro.kr")
                 .allowedMethods("GET", "POST", "PUT", "DELETE")
-                .allowedHeaders("*");
+                .allowedHeaders("*")
+                .allowCredentials(true);
     }
 
     @Override


### PR DESCRIPTION
# 이슈
- #57 

# 구현 내용
* [x] Response `Access-Control-Allow-Credentials` header 값 true 로 설정

# 참고한 글
[[네트워크] CORS와 credentials](https://velog.io/@garcon/%EB%84%A4%ED%8A%B8%EC%9B%8C%ED%81%AC-CORS%EC%99%80-credentials)

close #57 