### PR TITLE
feat: 예외 처리 Filter 추가

### DIFF
--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/common/filter/AuthorizationFilter.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/common/filter/AuthorizationFilter.java
@@ -9,6 +9,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.util.PathMatcher;
@@ -19,7 +20,8 @@ import java.util.List;
 
 @RequiredArgsConstructor
 @Component
-public class TokenFilter extends OncePerRequestFilter {
+@Order(1)
+public class AuthorizationFilter extends OncePerRequestFilter {
 
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String BEARER_PREFIX = "Bearer ";

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/common/filter/ExceptionHandlerFilter.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/common/filter/ExceptionHandlerFilter.java
@@ -1,0 +1,62 @@
+package com.canvas.bootstrap.common.filter;
+
+import com.canvas.bootstrap.common.exception.ExceptionResponse;
+import com.canvas.common.exception.BusinessException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Order(0)
+@Slf4j
+@Component
+public class ExceptionHandlerFilter extends OncePerRequestFilter {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (Exception e) {
+            handleException(response, e);
+        }
+    }
+
+    private void handleException(HttpServletResponse response, Exception e) throws IOException {
+        int status = getStatus(e);
+        setResponseHeaders(response, status);
+
+        ExceptionResponse errorResponse = new ExceptionResponse("000", e.getMessage());
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+
+    private int getStatus(Exception e) {
+        if (e instanceof BusinessException) {
+            log.error(e.getMessage());
+            return HttpServletResponse.SC_UNAUTHORIZED;
+        }
+        log.error("알 수 없는 서버 오류: {0}", e);
+
+        return HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
+    }
+
+    private void setResponseHeaders(HttpServletResponse response, int status) {
+        response.setStatus(status);
+        response.addHeader("Access-Control-Allow-Origin", "http://www.canvas-diary.kro.kr");
+        response.addHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
+        response.setHeader("Access-Control-Allow-Headers", "*");
+        response.setHeader("Access-Control-Allow-Credentials", "true");
+
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+    }
+
+}


### PR DESCRIPTION
- #59 
# 구현 내용
- [x] 예외 처리 필터 추가
- [x] TokenFilter 이름 변경 
# 고민 사항
- Filter 들의 예외 처리르 할 수 있도록 `ExceptionHandlerFilter`를 앞에 두었다.
- `ExceptionHandlerFilter`에서 CORS 문제가 발생하지 않도록 헤더값을 추가하였다.
- 해당 Filter에서 잡는 예외의 code는 일단 000으로 고정하였는데 어떻게 처리할지 추가적으로 고민할 필요가 있을 것 같다.
