### PR TITLE
feat: 일기 작성 중복 검사 추가

### DIFF
--- a/Application-Module/src/main/java/com/canvas/application/diary/port/in/AddDiaryUseCase.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/port/in/AddDiaryUseCase.java
@@ -2,14 +2,14 @@ package com.canvas.application.diary.port.in;
 
 import com.canvas.application.common.enums.Style;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 public interface AddDiaryUseCase {
     Response add(Command command);
 
     record Command(
             String userId,
-            LocalDateTime dateTime,
+            LocalDate date,
             String content,
             Style style,
             Boolean isPublic

--- a/Application-Module/src/main/java/com/canvas/application/diary/port/in/GetDiaryUseCase.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/port/in/GetDiaryUseCase.java
@@ -3,7 +3,6 @@ package com.canvas.application.diary.port.in;
 import com.canvas.domain.diary.enums.Emotion;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 
 public interface GetDiaryUseCase {
@@ -30,7 +29,7 @@ public interface GetDiaryUseCase {
                 Emotion emotion,
                 Integer likeCount,
                 Boolean isLiked,
-                LocalDateTime date,
+                LocalDate date,
                 Boolean isPublic,
                 List<ImageInfo> images
         ) {

--- a/Application-Module/src/main/java/com/canvas/application/diary/port/out/DiaryManagementPort.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/port/out/DiaryManagementPort.java
@@ -13,6 +13,7 @@ import java.util.List;
 
 public interface DiaryManagementPort {
     DiaryComplete save(DiaryComplete diary);
+    boolean existsByWriterIdAndDate(DomainId userId, LocalDate date);
     DiaryComplete getPublicById(DomainId diaryId);
     DiaryComplete getByIdAndWriterId(DomainId diaryId, DomainId writerId);
     boolean existsByIdAndWriterId(DomainId diaryId, DomainId writerId);

--- a/Application-Module/src/main/java/com/canvas/application/diary/service/DiaryCommandService.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/service/DiaryCommandService.java
@@ -28,6 +28,7 @@ public class DiaryCommandService
 
     @Override
     public Response add(AddDiaryUseCase.Command command) {
+
         DomainId diaryId = DomainId.generate();
         Emotion emotion = diaryEmotionExtractPort.emotionExtract(command.content());
         Image image = createImage(diaryId, command.content(), command.style());
@@ -38,7 +39,7 @@ public class DiaryCommandService
                         DomainId.from(command.userId()),
                         command.content(),
                         emotion,
-                        command.dateTime(),
+                        command.date(),
                         command.isPublic(),
                         image
                 )

--- a/Application-Module/src/main/java/com/canvas/application/diary/service/DiaryCommandService.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/service/DiaryCommandService.java
@@ -28,6 +28,9 @@ public class DiaryCommandService
 
     @Override
     public Response add(AddDiaryUseCase.Command command) {
+        if (diaryManagementPort.existsByWriterIdAndDate(DomainId.from(command.userId()), command.date())) {
+            throw new DiaryException.DiaryBadRequestException();
+        }
 
         DomainId diaryId = DomainId.generate();
         Emotion emotion = diaryEmotionExtractPort.emotionExtract(command.content());

--- a/Application-Module/src/main/java/com/canvas/application/diary/service/DiaryQueryService.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/service/DiaryQueryService.java
@@ -54,7 +54,7 @@ public class DiaryQueryService
                 diaries.stream()
                         .map(diary -> new GetDiaryUseCase.Response.HomeCalendar.DiaryInfo(
                                 diary.getId().toString(),
-                                diary.getDateTime().toLocalDate(),
+                                diary.getDate(),
                                 diary.getEmotion()
                         )).toList()
         );
@@ -68,7 +68,7 @@ public class DiaryQueryService
                 diary.getLikes().size(),
                 diary.getLikes().stream()
                         .anyMatch(like -> like.getUserId().equals(DomainId.from(userId))),
-                diary.getDateTime(),
+                diary.getDate(),
                 diary.getIsPublic(),
                 diary.getImages().stream()
                         .map(image -> new GetDiaryUseCase.Response.DiaryInfo.ImageInfo(

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/CreateDiaryRequest.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/CreateDiaryRequest.java
@@ -3,12 +3,12 @@ package com.canvas.bootstrap.diary.dto;
 import com.canvas.application.common.enums.Style;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Schema(description = "일기 생성 요청")
 public record CreateDiaryRequest(
         @Schema(description = "일기 생성 시간")
-        LocalDateTime date,
+        LocalDate date,
         @Schema(description = "일기 내용")
         String content,
         @Schema(description = "일기 화풍")

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/ReadMyDiaryResponse.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/ReadMyDiaryResponse.java
@@ -3,7 +3,7 @@ package com.canvas.bootstrap.diary.dto;
 import com.canvas.domain.diary.enums.Emotion;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 
 @Schema(description = "일기 조회 반환")
@@ -19,7 +19,7 @@ public record ReadMyDiaryResponse(
         @Schema(description = "일기 좋아요 선택 여부")
         Boolean isLiked,
         @Schema(description = "일기 생성 날짜")
-        LocalDateTime date,
+        LocalDate date,
         @Schema(description = "일기 공개 여부")
         Boolean isPublic,
         @Schema(description = "일기의 이미지 정보 리스트")

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/ReadOtherDiaryResponse.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/ReadOtherDiaryResponse.java
@@ -3,7 +3,7 @@ package com.canvas.bootstrap.diary.dto;
 import com.canvas.domain.diary.enums.Emotion;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 
 @Schema(description = "일기 조회 반환")
@@ -19,7 +19,7 @@ public record ReadOtherDiaryResponse(
         @Schema(description = "일기 좋아요 선택 여부")
         Boolean isLiked,
         @Schema(description = "일기 생성 날짜")
-        LocalDateTime date,
+        LocalDate date,
         @Schema(description = "일기의 이미지 정보 리스트")
         List<ImageInfo> images) {
     @Schema(description = "일기의 이미지 정보")

--- a/Domain-Module/src/main/java/com/canvas/domain/diary/entity/DiaryBasic.java
+++ b/Domain-Module/src/main/java/com/canvas/domain/diary/entity/DiaryBasic.java
@@ -5,6 +5,7 @@ import com.canvas.domain.diary.enums.Emotion;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @AllArgsConstructor
@@ -15,7 +16,7 @@ public class DiaryBasic {
     private DomainId writerId;
     private String content;
     private Emotion emotion;
-    private LocalDateTime dateTime;
+    private LocalDate date;
     private LocalDateTime createdAt;
     private Boolean isPublic;
 
@@ -24,10 +25,10 @@ public class DiaryBasic {
             DomainId writerId,
             String content,
             Emotion emotion,
-            LocalDateTime dateTime,
+            LocalDate date,
             LocalDateTime createdAt,
             Boolean isPublic
     ) {
-        return new DiaryBasic(id, writerId, content, emotion, dateTime, createdAt, isPublic);
+        return new DiaryBasic(id, writerId, content, emotion, date, createdAt, isPublic);
     }
 }

--- a/Domain-Module/src/main/java/com/canvas/domain/diary/entity/DiaryComplete.java
+++ b/Domain-Module/src/main/java/com/canvas/domain/diary/entity/DiaryComplete.java
@@ -6,6 +6,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -17,7 +18,7 @@ public class DiaryComplete {
     private DomainId writerId;
     private String content;
     private Emotion emotion;
-    private LocalDateTime dateTime;     // 일기 날짜
+    private LocalDate date;     // 일기 날짜
     private LocalDateTime createdAt;    // 일기가 생성된 실제 시각
     private Boolean isPublic;
     private List<Image> images;
@@ -28,7 +29,7 @@ public class DiaryComplete {
             DomainId writerId,
             String content,
             Emotion emotion,
-            LocalDateTime dateTime,
+            LocalDate date,
             LocalDateTime createdAt,
             Boolean isPublic,
             List<Image> images,
@@ -39,7 +40,7 @@ public class DiaryComplete {
                 writerId,
                 content,
                 emotion,
-                dateTime,
+                date,
                 createdAt,
                 isPublic,
                 images,
@@ -52,7 +53,7 @@ public class DiaryComplete {
             DomainId writerId,
             String content,
             Emotion emotion,
-            LocalDateTime dateTime,
+            LocalDate date,
             Boolean isPublic,
             Image image
     ) {
@@ -61,7 +62,7 @@ public class DiaryComplete {
                 writerId,
                 content,
                 emotion,
-                dateTime,
+                date,
                 null,
                 isPublic,
                 new ArrayList<>(List.of(image)),

--- a/Domain-Module/src/main/java/com/canvas/domain/diary/entity/DiaryOverview.java
+++ b/Domain-Module/src/main/java/com/canvas/domain/diary/entity/DiaryOverview.java
@@ -5,6 +5,7 @@ import com.canvas.domain.diary.enums.Emotion;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -16,7 +17,7 @@ public class DiaryOverview {
     private DomainId writerId;
     private String content;
     private Emotion emotion;
-    private LocalDateTime dateTime;
+    private LocalDate date;
     private LocalDateTime createdAt;
     private Boolean isPublic;
     private List<Image> images;
@@ -26,12 +27,12 @@ public class DiaryOverview {
             DomainId writerId,
             String content,
             Emotion emotion,
-            LocalDateTime dateTime,
+            LocalDate date,
             LocalDateTime createdAt,
             Boolean isPublic,
             List<Image> images
     ) {
-        return new DiaryOverview(id, writerId, content, emotion, dateTime, createdAt, isPublic, images);
+        return new DiaryOverview(id, writerId, content, emotion, date, createdAt, isPublic, images);
     }
 
     public String getMainImageOrDefault() {

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/DiaryMapper.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/DiaryMapper.java
@@ -14,7 +14,7 @@ public class DiaryMapper {
                 diary.getContent(),
                 diary.getEmotion().name(),
                 diary.getIsPublic(),
-                diary.getDateTime(),
+                diary.getDate(),
                 diary.getWriterId().value()
         );
 
@@ -30,7 +30,7 @@ public class DiaryMapper {
                 DomainId.from(diaryEntity.getWriterId()),
                 diaryEntity.getContent(),
                 Emotion.parse(diaryEntity.getEmotion()),
-                diaryEntity.getDateTime(),
+                diaryEntity.getDate(),
                 diaryEntity.getCreatedAt(),
                 diaryEntity.getIsPublic()
         );
@@ -42,7 +42,7 @@ public class DiaryMapper {
                 DomainId.from(diaryEntity.getWriterId()),
                 diaryEntity.getContent(),
                 Emotion.parse(diaryEntity.getEmotion()),
-                diaryEntity.getDateTime(),
+                diaryEntity.getDate(),
                 diaryEntity.getCreatedAt(),
                 diaryEntity.getIsPublic(),
                 diaryEntity.getImageEntities().stream()
@@ -57,7 +57,7 @@ public class DiaryMapper {
                 DomainId.from(diaryEntity.getWriterId()),
                 diaryEntity.getContent(),
                 Emotion.parse(diaryEntity.getEmotion()),
-                diaryEntity.getDateTime(),
+                diaryEntity.getDate(),
                 diaryEntity.getCreatedAt(),
                 diaryEntity.getIsPublic(),
                 diaryEntity.getImageEntities().stream()

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/adapter/DiaryManagementJpaAdapter.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/adapter/DiaryManagementJpaAdapter.java
@@ -17,8 +17,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 
@@ -55,12 +53,12 @@ public class DiaryManagementJpaAdapter implements DiaryManagementPort {
 
     @Override
     public List<DiaryBasic> getByUserIdAndMonth(DomainId userId, LocalDate date) {
-        LocalDateTime start = date.with(TemporalAdjusters.firstDayOfMonth()).atStartOfDay();
-        LocalDateTime end = date.with(TemporalAdjusters.lastDayOfMonth()).atTime(LocalTime.MAX);
+        LocalDate start = date.with(TemporalAdjusters.firstDayOfMonth());
+        LocalDate end = date.with(TemporalAdjusters.lastDayOfMonth());
 
-        return diaryJpaRepository.findByWriterIdAndDateTimeBetween(userId.value(), start, end).stream()
-                .map(DiaryMapper::toBasicDomain)
-                .toList();
+        return diaryJpaRepository.findByWriterIdAndDateBetween(userId.value(), start, end).stream()
+                                 .map(DiaryMapper::toBasicDomain)
+                                 .toList();
     }
 
     @Override

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/adapter/DiaryManagementJpaAdapter.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/adapter/DiaryManagementJpaAdapter.java
@@ -33,6 +33,11 @@ public class DiaryManagementJpaAdapter implements DiaryManagementPort {
     }
 
     @Override
+    public boolean existsByWriterIdAndDate(DomainId userId, LocalDate date) {
+        return diaryJpaRepository.existsByWriterIdAndDate(userId.value(), date);
+    }
+
+    @Override
     public DiaryComplete getPublicById(DomainId diaryId) {
         DiaryEntity diaryEntity = diaryJpaRepository.findByIdAndIsPublicTrue(diaryId.value())
                 .orElseThrow(DiaryException.DiaryNotFoundException::new);

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/entity/DiaryEntity.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/entity/DiaryEntity.java
@@ -7,7 +7,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -25,7 +25,7 @@ public class DiaryEntity extends BaseEntity {
     private String content;
     private String emotion;
     private Boolean isPublic;
-    private LocalDateTime dateTime;
+    private LocalDate date;
 
     @Column(name = "writer_id", nullable = false)
     private UUID writerId;
@@ -39,12 +39,12 @@ public class DiaryEntity extends BaseEntity {
     @OneToMany(mappedBy = "diaryEntity", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<LikeEntity> likeEntities = new ArrayList<>();
 
-    public DiaryEntity(UUID id, String content, String emotion, Boolean isPublic, LocalDateTime dateTime, UUID writerId) {
+    public DiaryEntity(UUID id, String content, String emotion, Boolean isPublic, LocalDate date, UUID writerId) {
         this.id = id;
         this.content = content;
         this.emotion = emotion;
         this.isPublic = isPublic;
-        this.dateTime = dateTime;
+        this.date = date;
         this.writerId = writerId;
     }
 

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/repository/DiaryJpaRepository.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/repository/DiaryJpaRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -32,10 +32,10 @@ public interface DiaryJpaRepository extends JpaRepository<DiaryEntity, UUID> {
         select d
         from DiaryEntity d
         left join fetch d.likeEntities
-        where d.writerId = :writerId and d.dateTime between :start and :end
-        order by d.dateTime asc
+        where d.writerId = :writerId and d.date between :start and :end
+        order by d.date asc
     """)
-    List<DiaryEntity> findByWriterIdAndDateTimeBetween(UUID writerId, LocalDateTime start, LocalDateTime end);
+    List<DiaryEntity> findByWriterIdAndDateBetween(UUID writerId, LocalDate start, LocalDate end);
 
     Slice<DiaryEntity> findByWriterId(Pageable pageable, UUID writerId);
     Slice<DiaryEntity> findByWriterIdAndContentContains(Pageable pageable, UUID writerId, String content);

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/repository/DiaryJpaRepository.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/repository/DiaryJpaRepository.java
@@ -12,6 +12,8 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface DiaryJpaRepository extends JpaRepository<DiaryEntity, UUID> {
+    boolean existsByWriterIdAndDate(UUID writerId, LocalDate date);
+
     @Query("""
         select d
         from DiaryEntity d

--- a/Infrastructure-Module/Persistence/src/test/java/com/canvas/persistence/jpa/diary/repository/DiaryJpaRepositoryTest.java
+++ b/Infrastructure-Module/Persistence/src/test/java/com/canvas/persistence/jpa/diary/repository/DiaryJpaRepositoryTest.java
@@ -102,15 +102,15 @@ class DiaryJpaRepositoryTest {
 
     @Test
     @DisplayName("작성자 ID, 기간 조회 성공")
-    void findByWriterIdAndDateTimeBetweenSuccessTest() {
+    void findByWriterIdAndDateBetweenSuccessTest() {
         // given
         DiaryEntity publicMyDiary = PUBLIC_MY_DIARY.getDiaryEntity();
 
         // when
-        List<DiaryEntity> diaryEntities = diaryJpaRepository.findByWriterIdAndDateTimeBetween(
+        List<DiaryEntity> diaryEntities = diaryJpaRepository.findByWriterIdAndDateBetween(
                 publicMyDiary.getWriterId(),
-                publicMyDiary.getDateTime().minusDays(1),
-                publicMyDiary.getDateTime().plusDays(1)
+                publicMyDiary.getDate().minusDays(1),
+                publicMyDiary.getDate().plusDays(1)
         );
 
         // then
@@ -121,15 +121,15 @@ class DiaryJpaRepositoryTest {
 
     @Test
     @DisplayName("작성자 ID, 기간 조회 실패")
-    void findByWriterIdAndDateTimeBetweenFailureTest() {
+    void findByWriterIdAndDateBetweenFailureTest() {
         // given
         DiaryEntity publicMyDiary = PUBLIC_MY_DIARY.getDiaryEntity();
 
         // when
-        List<DiaryEntity> diaryEntities = diaryJpaRepository.findByWriterIdAndDateTimeBetween(
+        List<DiaryEntity> diaryEntities = diaryJpaRepository.findByWriterIdAndDateBetween(
                 publicMyDiary.getWriterId(),
-                publicMyDiary.getDateTime().plusDays(1),
-                publicMyDiary.getDateTime().plusDays(2)
+                publicMyDiary.getDate().plusDays(1),
+                publicMyDiary.getDate().plusDays(2)
         );
 
         // then

--- a/Infrastructure-Module/Persistence/src/testFixtures/java/com/canvas/persistence/jpa/builder/DiaryEntityBuilder.java
+++ b/Infrastructure-Module/Persistence/src/testFixtures/java/com/canvas/persistence/jpa/builder/DiaryEntityBuilder.java
@@ -6,7 +6,7 @@ import com.canvas.persistence.jpa.diary.entity.LikeEntity;
 import com.canvas.persistence.jpa.user.entity.UserEntity;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
@@ -16,7 +16,7 @@ public class DiaryEntityBuilder {
     private String content;
     private String emotion;
     private Boolean isPublic;
-    private LocalDateTime dateTime;
+    private LocalDate date;
     private UUID writerId;
     private UserEntity writer;
     private List<ImageEntity> imageEntities;
@@ -42,8 +42,8 @@ public class DiaryEntityBuilder {
         return this;
     }
 
-    public DiaryEntityBuilder dateTime(LocalDateTime dateTime) {
-        this.dateTime = dateTime;
+    public DiaryEntityBuilder date(LocalDate date) {
+        this.date = date;
         return this;
     }
 
@@ -73,7 +73,7 @@ public class DiaryEntityBuilder {
                 this.content,
                 this.emotion,
                 this.isPublic,
-                this.dateTime,
+                this.date,
                 this.writerId
         );
 

--- a/Infrastructure-Module/Persistence/src/testFixtures/java/com/canvas/persistence/jpa/fixture/DiaryEntityFixture.java
+++ b/Infrastructure-Module/Persistence/src/testFixtures/java/com/canvas/persistence/jpa/fixture/DiaryEntityFixture.java
@@ -6,7 +6,6 @@ import com.canvas.persistence.jpa.diary.entity.DiaryEntity;
 import lombok.Getter;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.UUID;
 
@@ -17,7 +16,7 @@ public enum DiaryEntityFixture {
             "내용1",
             "감정1",
             true,
-            LocalDate.of(2024, 10, 15).atStartOfDay(),
+            LocalDate.of(2024, 10, 15),
             MYSELF
     ),
 
@@ -25,7 +24,7 @@ public enum DiaryEntityFixture {
             "내용2",
             "감정2",
             true,
-            LocalDate.of(2024, 10, 17).atStartOfDay(),
+            LocalDate.of(2024, 10, 17),
             OTHER1
     ),
 
@@ -33,7 +32,7 @@ public enum DiaryEntityFixture {
             "내용3",
             "감정3",
             false,
-            LocalDate.of(2024, 10, 31).atStartOfDay(),
+            LocalDate.of(2024, 10, 31),
             OTHER2
     );
 
@@ -42,15 +41,15 @@ public enum DiaryEntityFixture {
     private final String content;
     private final String emotion;
     private final Boolean isPublic;
-    private final LocalDateTime dateTime;
+    private final LocalDate date;
     private final UserEntityFixture userEntityFixture;
 
-    DiaryEntityFixture(String content, String emotion, Boolean isPublic, LocalDateTime dateTime, UserEntityFixture userEntityFixture) {
+    DiaryEntityFixture(String content, String emotion, Boolean isPublic, LocalDate date, UserEntityFixture userEntityFixture) {
         this.id = DomainId.generate().value();
         this.content = content;
         this.emotion = emotion;
         this.isPublic = isPublic;
-        this.dateTime = dateTime;
+        this.date = date;
         this.userEntityFixture = userEntityFixture;
     }
 
@@ -60,7 +59,7 @@ public enum DiaryEntityFixture {
                 .content(content)
                 .emotion(emotion)
                 .isPublic(isPublic)
-                .dateTime(dateTime)
+                .date(date)
                 .writerId(userEntityFixture.getId())
                 .writer(userEntityFixture.getUserEntity())
                 .imageEntities(


### PR DESCRIPTION
# 이슈
- #47 

# 구현한 내용
* [x] Diary 도메인, 엔티티 일기 날짜 타입 변경
* [x] 일기 작성 시 중복 검사 로직 추가

# 상세 내용
## Diary 도메인, 엔티티 일기 날짜 타입 변경
- `dateTime` 필드 `LocalDateTime`에서 `LocalDate`로 변경

## 일기 작성 시 중복 검사 로직 추가
```java
if (diaryManagementPort.existsByWriterIdAndDate(DomainId.from(command.userId()), command.date())) {
    throw new DiaryException.DiaryBadRequestException();
}
```

close #47 