### PR TITLE
feat: diary controller 수정, 삭제 부분 연결

### DIFF
--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/api/DiaryApi.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/api/DiaryApi.java
@@ -70,7 +70,7 @@ public interface DiaryApi {
                     description = "일기 내용 수정 성공"
             )
     })
-    void updateDiary(@PathVariable String diaryId, @RequestBody UpdateDiaryRequest updateDiaryRequest);
+    void updateDiary(@AccessUser String userId, @PathVariable String diaryId, @RequestBody UpdateDiaryRequest updateDiaryRequest);
 
     @Operation(summary = "일기 삭제")
     @DeleteMapping("/{diaryId}")
@@ -80,7 +80,7 @@ public interface DiaryApi {
                     description = "일기 삭제 성공"
             )
     })
-    void deleteDiary(@PathVariable String diaryId);
+    void deleteDiary(@AccessUser String userId, @PathVariable String diaryId);
 
     @Operation(summary = "일기 검색")
     @GetMapping("/search")

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/controller/DiaryController.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/controller/DiaryController.java
@@ -85,14 +85,20 @@ public class DiaryController implements DiaryApi {
                         .toList());
     }
 
+    // 그날의 일기 일기 다시 재생성
+    // 일기 수정할 때 그림 자체를 재생성하는데, 일기 내용 수정만 하는 경우도 생각해야 할 것 같음.
     @Override
-    public void updateDiary(String diaryId, UpdateDiaryRequest request) {
-
+    public void updateDiary(String userId, String diaryId, UpdateDiaryRequest request) {
+        modifyDiaryUseCase.modify(new ModifyDiaryUseCase.Command(
+                userId, diaryId, request.content(), request.style(), request.isPublic()
+        ));
     }
 
     @Override
-    public void deleteDiary(String diaryId) {
-
+    public void deleteDiary(String userId, String diaryId) {
+        removeDiaryUseCase.remove(new RemoveDiaryUseCase.Command(
+                diaryId, userId
+        ));
     }
 
     @Override

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/UpdateDiaryRequest.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/UpdateDiaryRequest.java
@@ -1,11 +1,14 @@
 package com.canvas.bootstrap.diary.dto;
 
+import com.canvas.application.common.enums.Style;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "일기 수정 요청")
 public record UpdateDiaryRequest(
         @Schema(description = "일기 내용")
         String content,
+        @Schema(description = "일기 화풍")
+        Style style,
         @Schema(description = "일기 공개 여부")
         boolean isPublic
 ) {


### PR DESCRIPTION
# 구현 내용
일기 수정, 일기 삭제 부분 controller Usercase와 연결하였다.

일기 수정 시 그림도 다시 생성하고, 공개, 비공개 여부도 다시 결정하는데 간단하게 일기 내용만 수정할 수 있는 로직이 추가적으로 필요할 것 같다.