### PR TITLE
fix: token 값이 없을 때 예외 처리하도록 수정

### DIFF
--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/common/filter/AuthorizationFilter.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/common/filter/AuthorizationFilter.java
@@ -2,6 +2,7 @@ package com.canvas.bootstrap.common.filter;
 
 import com.canvas.application.user.port.in.TokenResolveUserCase;
 import com.canvas.application.user.vo.UserClaim;
+import com.canvas.common.exception.BusinessException;
 import com.canvas.common.security.UserAuthentication;
 import com.canvas.common.security.UserContextHolder;
 import jakarta.servlet.FilterChain;
@@ -10,6 +11,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.util.PathMatcher;
@@ -41,13 +43,16 @@ public class AuthorizationFilter extends OncePerRequestFilter {
         }
 
         String authorization = request.getHeader(AUTHORIZATION_HEADER);
-        if(authorization != null && authorization.startsWith(BEARER_PREFIX)) {
-            String accessToken = authorization.substring(BEARER_PREFIX.length());
-            // 토큰 검증
-            UserClaim userClaim = tokenResolveUserCase.resolveToken(accessToken);
-            // 에노테이션에 담기
-            UserContextHolder.setContext(new UserAuthentication(userClaim.userId()));
+
+        if(!(authorization != null && authorization.startsWith(BEARER_PREFIX))) {
+            throw new AuthorizationFilterException();
         }
+        String accessToken = authorization.substring(BEARER_PREFIX.length());
+        // 토큰 검증
+        UserClaim userClaim = tokenResolveUserCase.resolveToken(accessToken);
+        // 에노테이션에 담기
+        UserContextHolder.setContext(new UserAuthentication(userClaim.userId()));
+
 
         filterChain.doFilter(request, response);
 
@@ -59,4 +64,19 @@ public class AuthorizationFilter extends OncePerRequestFilter {
         return excludedAuthUrls.stream().anyMatch(pattern -> pathMatcher.match(pattern, requestURI));
     }
 
+
+    static class AuthorizationFilterException extends BusinessException {
+
+        private static final String CODE_PREFIX = "AUTH_FILTER";
+        private static final String DEFAULT_MESSAGE = "필터 인증 예외가 발생했습니다.";
+        private static final HttpStatus DEFAULT_HTTP_STATUS = HttpStatus.UNAUTHORIZED;
+
+        public AuthorizationFilterException() {
+            super(CODE_PREFIX, 0, DEFAULT_HTTP_STATUS, DEFAULT_MESSAGE);
+        }
+
+        public AuthorizationFilterException(String codePrefix, int errorCode, HttpStatus httpStatus, String message) {
+            super(codePrefix, errorCode, httpStatus, message);
+        }
+    }
 }


### PR DESCRIPTION
# 구현 내용
- 토큰 값이 없을 때 401 에러를 던지지 않아서 401 에러 예외를 던지도록 수정하였다.
- 이 예외는 AuthorizationFilter에서만 예외가 발생한다고 판단하여 static class로 BusinessException을 상속받아서 구현하였다