### PR TITLE
feat: 좋아요 누른 일기 조회 기능 추가

### DIFF
--- a/Application-Module/src/main/java/com/canvas/application/diary/port/in/GetDiaryUseCase.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/port/in/GetDiaryUseCase.java
@@ -9,6 +9,8 @@ public interface GetDiaryUseCase {
     Response.DiaryInfo getMyDiary(Query.Diary query);
     Response.DiaryInfo getOtherDiary(Query.Diary query);
     Response.HomeCalendar getHomeCalendar(Query.HomeCalendar query);
+    Response.LikedDiaries getLikedDiaries(Query.LikedDiaries query);
+
 
     class Query {
         public record Diary(
@@ -19,6 +21,12 @@ public interface GetDiaryUseCase {
         public record HomeCalendar(
                 String userId,
                 LocalDate date
+        ) {}
+
+        public record LikedDiaries(
+                String userId,
+                Integer page,
+                Integer size
         ) {}
     }
 
@@ -47,6 +55,18 @@ public interface GetDiaryUseCase {
                     String diaryId,
                     LocalDate date,
                     Emotion emotion
+            ) {}
+        }
+
+        public record LikedDiaries(
+                List<DiaryInfo> diaries,
+                Integer size,
+                Integer number,
+                Boolean hasNext
+        ) {
+            public record DiaryInfo(
+                    String diaryId,
+                    String mainImageUrl
             ) {}
         }
     }

--- a/Application-Module/src/main/java/com/canvas/application/diary/port/out/DiaryManagementPort.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/port/out/DiaryManagementPort.java
@@ -24,5 +24,6 @@ public interface DiaryManagementPort {
     Slice<DiaryOverview> getAlbumByContentAndEmotion(PageRequest pageRequest, DomainId userId, String content, Emotion emotion);
     Slice<DiaryOverview> getExploreByLatest(PageRequest pageRequest);
     Slice<DiaryOverview> getExploreByLike(PageRequest pageRequest);
+    Slice<DiaryOverview> getLikedDiaries(PageRequest pageRequest, DomainId userId);
     void deleteById(DomainId diaryId);
 }

--- a/Application-Module/src/main/java/com/canvas/application/diary/service/DiaryQueryService.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/service/DiaryQueryService.java
@@ -60,6 +60,25 @@ public class DiaryQueryService
         );
     }
 
+    @Override
+    public GetDiaryUseCase.Response.LikedDiaries getLikedDiaries(GetDiaryUseCase.Query.LikedDiaries query) {
+        Slice<DiaryOverview> slice = diaryManagementPort.getLikedDiaries(
+                new PageRequest(query.page(), query.size(), Sort.by(Sort.Direction.DESC, "createdAt")),
+                DomainId.from(query.userId())
+        );
+
+        return new GetDiaryUseCase.Response.LikedDiaries(
+                slice.content().stream()
+                     .map(diary -> new GetDiaryUseCase.Response.LikedDiaries.DiaryInfo(
+                             diary.getId().toString(),
+                             diary.getMainImageOrDefault()))
+                     .toList(),
+                slice.size(),
+                slice.number(),
+                slice.hasNext()
+        );
+    }
+
     private static GetDiaryUseCase.Response.DiaryInfo toResponseDiary(String userId, DiaryComplete diary) {
         return new GetDiaryUseCase.Response.DiaryInfo(
                 diary.getId().toString(),

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/api/DiaryApi.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/api/DiaryApi.java
@@ -141,5 +141,37 @@ public interface DiaryApi {
                     description = "쿼리 스트링 오류"
             )
     })
-    SliceResponse<DiaryThumbnail> exploreDiary(@RequestParam int page, @RequestParam int size, @RequestParam ExploreOrder order);
+    SliceResponse<DiaryThumbnail> exploreDiary(
+            @RequestParam int page,
+            @RequestParam int size,
+            @RequestParam ExploreOrder order
+    );
+
+    @Operation(summary = "좋아요 누른 일기 조회")
+    @GetMapping("/like")
+    @Parameters({
+            @Parameter(
+                    name = "page",
+                    description = "요청할 페이지 번호"
+            ),
+            @Parameter(
+                    name = "size",
+                    description = "요청할 페이지 크기"
+            )
+    })
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "일기 탐색 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "쿼리 스트링 오류"
+            )
+    })
+    SliceResponse<DiaryThumbnail> readLikedDiary(
+            @AccessUser String userId,
+            @RequestParam Integer page,
+            @RequestParam Integer size
+    );
 }

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/controller/DiaryController.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/controller/DiaryController.java
@@ -15,6 +15,7 @@ public class DiaryController implements DiaryApi {
 
     private final AddDiaryUseCase addDiaryUseCase;
     private final GetDiaryUseCase getDiaryUseCase;
+
     private final GetAlbumDiaryUseCase getAlbumDiaryUseCase;
     private final GetExploreDiaryUseCase getExploreDiaryUseCase;
     private final ModifyDiaryUseCase modifyDiaryUseCase;
@@ -151,4 +152,25 @@ public class DiaryController implements DiaryApi {
                 response.hasNext()
         );
     }
+
+    @Override
+    public SliceResponse<DiaryThumbnail> readLikedDiary(String userId, Integer page, Integer size) {
+        GetDiaryUseCase.Response.LikedDiaries response = getDiaryUseCase.getLikedDiaries(
+                new GetDiaryUseCase.Query.LikedDiaries(
+                        userId,
+                        page,
+                        size
+                )
+        );
+
+        return new SliceResponse<>(
+                response.diaries().stream()
+                        .map(diaryInfo -> new DiaryThumbnail(diaryInfo.diaryId(), diaryInfo.mainImageUrl()))
+                        .toList(),
+                response.size(),
+                response.number(),
+                response.hasNext()
+        );
+    }
+
 }

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/adapter/DiaryManagementJpaAdapter.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/adapter/DiaryManagementJpaAdapter.java
@@ -134,6 +134,16 @@ public class DiaryManagementJpaAdapter implements DiaryManagementPort {
     }
 
     @Override
+    public Slice<DiaryOverview> getLikedDiaries(PageRequest pageRequest, DomainId userId) {
+        var diaryEntities = diaryJpaRepository.findByUserLiked(
+                PageMapper.toJpaPageRequest(pageRequest),
+                userId.value()
+        );
+
+        return PageMapper.toDomainSlice(diaryEntities, DiaryMapper::toOverviewDomain);
+    }
+
+    @Override
     public void deleteById(DomainId diaryId) {
         diaryJpaRepository.deleteById(diaryId.value());
     }

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/repository/DiaryJpaRepository.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/repository/DiaryJpaRepository.java
@@ -55,5 +55,14 @@ public interface DiaryJpaRepository extends JpaRepository<DiaryEntity, UUID> {
     """)
     Slice<DiaryEntity> findAllByIsPublicTrueOrderByLikeCountDesc(Pageable pageable);
 
+    @Query("""
+        select d
+        from DiaryEntity d
+        where d.id in (select l.diaryId
+                       from LikeEntity l
+                       where l.userId = :userId)
+    """)
+    Slice<DiaryEntity> findByUserLiked(Pageable pageable, UUID userId);
+
     boolean existsByIdAndWriterId(UUID diaryId, UUID writerId);
 }


### PR DESCRIPTION
# 이슈
- #82 

# 구현 내용
- 좋아요 누른 일기 조회 기능 추가

# 상세 내용
### DiaryJpaRepository
```java
@Query("""
    select d
    from DiaryEntity d
    where d.id in (select l.diaryId
                   from LikeEntity l
                   where l.userId = :userId)
""")
Slice<DiaryEntity> findByUserLiked(Pageable pageable, UUID userId);
```
- `DiaryJpaRepository` `userId`를 가진 사용자가 좋아요를 누른 `DiaryEntity` 반환
- 그 외 구현사항은 탐색, 앨범 조회 기능과 동일

close #82 