### PR TITLE
feat: 이미지 생성 API 스펙 변경

### DIFF
--- a/Application-Module/src/main/java/com/canvas/application/diary/service/DiaryCommandService.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/service/DiaryCommandService.java
@@ -70,7 +70,7 @@ public class DiaryCommandService
     }
 
     private Image createImage(DomainId diaryId, String content, Style style) {
-        String imageUrl = addImageUseCase.create(new AddImageUseCase.Command(diaryId.toString(), content, style)).imageUrl();
+        String imageUrl = addImageUseCase.create(new AddImageUseCase.Command.Create(diaryId.toString(), content, style)).imageUrl();
         return Image.create(DomainId.generate(), diaryId, true, imageUrl);
     }
 

--- a/Application-Module/src/main/java/com/canvas/application/image/port/in/AddImageUseCase.java
+++ b/Application-Module/src/main/java/com/canvas/application/image/port/in/AddImageUseCase.java
@@ -3,25 +3,33 @@ package com.canvas.application.image.port.in;
 import com.canvas.application.common.enums.Style;
 
 public interface AddImageUseCase {
-    Response.add add(Command command);
-    Response.create create(Command command);
+    Response.Add add(Command.Add command);
+    Response.Create create(Command.Create command);
 
-    record Command(
-            String diaryId,
-            String content,
-            Style style
-    ) {
+    class Command {
+        public record Add(
+                String diaryId,
+                Style style
+        ) {
+        }
+
+        public record Create(
+                String diaryId,
+                String content,
+                Style style
+        ) {
+        }
     }
 
     class Response {
-        public record add(
+        public record Add(
                 String imageId,
                 Boolean isMain,
                 String imageUrl
         ) {
         }
 
-        public record create(
+        public record Create(
                 String imageUrl
         ) {}
     }

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/image/controllor/ImageController.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/image/controllor/ImageController.java
@@ -19,9 +19,7 @@ public class ImageController implements ImageApi {
     @Override
     public void createImage(String userId, String diaryId, CreateImageRequest createImageRequest) {
         addImageUseCase.add(
-                new AddImageUseCase.Command(
-                        diaryId, createImageRequest.content(), createImageRequest.style()
-                ));
+                new AddImageUseCase.Command.Add(diaryId, createImageRequest.style()));
     }
 
     @Override

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/image/dto/CreateImageRequest.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/image/dto/CreateImageRequest.java
@@ -5,8 +5,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "이미지 추가 요청")
 public record CreateImageRequest(
-        @Schema(description = "일기 내용")
-        String content,
         @Schema(description = "일기 화풍")
         Style style
 ) {


### PR DESCRIPTION
# 구현 내용
* [x] 이미지 생성 API 요청 스펙 변경
* [x] 이미지 생성 로직 리팩토링 

# 세부 내용
## 이미지 생성 API 요청 스펙 변경
### CreateImageRequest
```java
@Schema(description = "이미지 추가 요청")
public record CreateImageRequest(
        @Schema(description = "일기 화풍")
        Style style
) {
```
- 이미지 생성 API 요청 body `style`만 받도록 변경

## 이미지 생성 로직 리팩토링 
### AddImageUseCase
```java
class Command {
    public record Add(
            String diaryId,
            Style style
    ) {
    }

    public record Create(
            String diaryId,
            String content,
            Style style
    ) {
    }
}
```
- `Add`, `Create` DTO 분리

### ImageCommandService
```java
DiaryComplete diary = diaryManagementPort.getById(diaryId);

Response.Create create = create(
        new AddImageUseCase.Command.Create(command.diaryId(), diary.getContent(), command.style()));
```
- 기존 `command` DTO에서 `content`를 가져오는 것에서 `diaryId`로 조회한 `DiaryComplete`에서 `content`를 가져오는 것으로 변경