### PR TITLE
feat: 일기 수정 API 스펙 변경

### DIFF
--- a/Application-Module/src/main/java/com/canvas/application/diary/port/in/ModifyDiaryUseCase.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/port/in/ModifyDiaryUseCase.java
@@ -1,7 +1,5 @@
 package com.canvas.application.diary.port.in;
 
-import com.canvas.application.common.enums.Style;
-
 public interface ModifyDiaryUseCase {
     void modify(Command command);
 
@@ -9,7 +7,6 @@ public interface ModifyDiaryUseCase {
             String userId,
             String diaryId,
             String content,
-            Style style,
             Boolean isPublic
     ) {
     }

--- a/Application-Module/src/main/java/com/canvas/application/diary/service/DiaryCommandService.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/service/DiaryCommandService.java
@@ -53,17 +53,16 @@ public class DiaryCommandService
 
     @Override
     public void modify(ModifyDiaryUseCase.Command command) {
-        DomainId diarId = DomainId.from(command.diaryId());
-
         DiaryComplete diary = diaryManagementPort.getByIdAndWriterId(
-                diarId,
+                DomainId.from(command.diaryId()),
                 DomainId.from(command.userId())
         );
 
-        Emotion emotion = diaryEmotionExtractPort.emotionExtract(command.content());
-        Image image = createImage(diarId, command.content(), command.style());
+        if (!command.content().equals(diary.getContent())) {
+            Emotion emotion = diaryEmotionExtractPort.emotionExtract(command.content());
+            diary.updateDiaryContent(command.content(), emotion);
+        }
 
-        diary.updateDiaryContent(command.content(), emotion, image);
         diary.updatePublic(command.isPublic());
 
         diaryManagementPort.save(diary);

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/api/DiaryApi.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/api/DiaryApi.java
@@ -51,7 +51,7 @@ public interface DiaryApi {
 
 
     @Operation(summary = "일기 내용 수정")
-    @PatchMapping("/{diaryId}")
+    @PutMapping("/{diaryId}")
     @ApiResponses(value = {
             @ApiResponse(
                     responseCode = "200",

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/controller/DiaryController.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/controller/DiaryController.java
@@ -74,7 +74,7 @@ public class DiaryController implements DiaryApi {
     @Override
     public void updateDiary(String userId, String diaryId, UpdateDiaryRequest request) {
         modifyDiaryUseCase.modify(new ModifyDiaryUseCase.Command(
-                userId, diaryId, request.content(), request.style(), request.isPublic()
+                userId, diaryId, request.content(), request.isPublic()
         ));
     }
 

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/UpdateDiaryRequest.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/UpdateDiaryRequest.java
@@ -1,15 +1,12 @@
 package com.canvas.bootstrap.diary.dto;
 
-import com.canvas.application.common.enums.Style;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "일기 수정 요청")
 public record UpdateDiaryRequest(
         @Schema(description = "일기 내용")
         String content,
-        @Schema(description = "일기 화풍")
-        Style style,
         @Schema(description = "일기 공개 여부")
-        boolean isPublic
+        Boolean isPublic
 ) {
 }


### PR DESCRIPTION
# 구현 내용
* [x] 일기 수정 API PATCH 메소드에서 PUT 메소드로 변경
* [x] 요청 body에서 `style` 삭제
* [x] 일기 수정 시 그림을 새로 생성하지 않고 내용만 수정

# 세부 내용
## 일기 수정 API PATCH 메소드에서 PUT 메소드로 변경
- Spring에서 PATCH 메소드를 구현하기 까다로움
- PUT 메소드로 전부 받는 방향으로 결정

## 일기 수정 시 그림을 새로 생성하지 않고 내용만 수정
- 그림을 새로 생성하지 않으므로 화풍 `style` 속성 삭제

### DiaryCommandService
```java
if (!command.content().equals(diary.getContent())) {
    Emotion emotion = diaryEmotionExtractPort.emotionExtract(command.content());
    diary.updateDiaryContent(command.content(), emotion);
}
```
- 내용이 수정되었으면 감정을 새로 추출, 내용과 같이 감정 수정