### PR TITLE
feat: 일기 탐색 API 스펙 변경

### DIFF
--- a/Application-Module/src/main/java/com/canvas/application/diary/port/in/GetExploreDiaryUseCase.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/port/in/GetExploreDiaryUseCase.java
@@ -7,6 +7,7 @@ public interface GetExploreDiaryUseCase {
     Response getExploreByLike(Query query);
 
     record Query(
+            String userId,
             Integer page,
             Integer size
     ) {}
@@ -19,7 +20,8 @@ public interface GetExploreDiaryUseCase {
     ) {
         public record DiaryInfo(
                 String diaryId,
-                String mainImageUrl
+                String mainImageUrl,
+                Boolean isLiked
         ) {}
     }
 }

--- a/Application-Module/src/main/java/com/canvas/application/diary/port/out/DiaryManagementPort.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/port/out/DiaryManagementPort.java
@@ -22,8 +22,8 @@ public interface DiaryManagementPort {
     Slice<DiaryOverview> getAlbumByContent(PageRequest pageRequest, DomainId userId, String content);
     Slice<DiaryOverview> getAlbumByEmotion(PageRequest pageRequest, DomainId userId, Emotion emotion);
     Slice<DiaryOverview> getAlbumByContentAndEmotion(PageRequest pageRequest, DomainId userId, String content, Emotion emotion);
-    Slice<DiaryOverview> getExploreByLatest(PageRequest pageRequest);
-    Slice<DiaryOverview> getExploreByLike(PageRequest pageRequest);
+    Slice<DiaryComplete> getExploreByLatest(PageRequest pageRequest);
+    Slice<DiaryComplete> getExploreByLike(PageRequest pageRequest);
     Slice<DiaryOverview> getLikedDiaries(PageRequest pageRequest, DomainId userId);
     void deleteById(DomainId diaryId);
 }

--- a/Application-Module/src/main/java/com/canvas/application/diary/service/DiaryQueryService.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/service/DiaryQueryService.java
@@ -151,26 +151,27 @@ public class DiaryQueryService
 
     @Override
     public GetExploreDiaryUseCase.Response getExploreByLatest(GetExploreDiaryUseCase.Query query) {
-        Slice<DiaryOverview> slice = diaryManagementPort.getExploreByLatest(
+        Slice<DiaryComplete> slice = diaryManagementPort.getExploreByLatest(
                 new PageRequest(query.page(), query.size(), Sort.by(Sort.Direction.DESC, "createdAt")));
 
-        return toExploreResponse(slice);
+        return toExploreResponse(DomainId.from(query.userId()), slice);
     }
 
     @Override
     public GetExploreDiaryUseCase.Response getExploreByLike(GetExploreDiaryUseCase.Query query) {
-        Slice<DiaryOverview> slice = diaryManagementPort.getExploreByLike(
+        Slice<DiaryComplete> slice = diaryManagementPort.getExploreByLike(
                 new PageRequest(query.page(), query.size(), Sort.by(Sort.Direction.DESC, "createdAt")));
 
-        return toExploreResponse(slice);
+        return toExploreResponse(DomainId.from(query.userId()), slice);
     }
 
-    private static GetExploreDiaryUseCase.Response toExploreResponse(Slice<DiaryOverview> slice) {
+    private static GetExploreDiaryUseCase.Response toExploreResponse(DomainId userId, Slice<DiaryComplete> slice) {
         return new GetExploreDiaryUseCase.Response(
                 slice.content().stream()
                         .map(diary -> new GetExploreDiaryUseCase.Response.DiaryInfo(
                                 diary.getId().toString(),
-                                diary.getMainImageOrDefault()))
+                                diary.getMainImageOrDefault(),
+                                diary.isLiked(userId)))
                         .toList(),
                 slice.size(),
                 slice.number(),

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/api/DiaryApi.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/api/DiaryApi.java
@@ -130,7 +130,8 @@ public interface DiaryApi {
                     description = "쿼리 스트링 오류"
             )
     })
-    SliceResponse<DiaryThumbnail> exploreDiary(
+    SliceResponse<ExploreDiaryResponse> exploreDiary(
+            @AccessUser String userId,
             @RequestParam int page,
             @RequestParam int size,
             @RequestParam ExploreOrder order

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/controller/DiaryController.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/controller/DiaryController.java
@@ -121,15 +121,18 @@ public class DiaryController implements DiaryApi {
     }
 
     @Override
-    public SliceResponse<DiaryThumbnail> exploreDiary(int page, int size, ExploreOrder order) {
+    public SliceResponse<ExploreDiaryResponse> exploreDiary(String userId, int page, int size, ExploreOrder order) {
         GetExploreDiaryUseCase.Response response = switch (order) {
-            case LATEST -> getExploreDiaryUseCase.getExploreByLatest(new GetExploreDiaryUseCase.Query(page, size));
-            case POPULARITY -> getExploreDiaryUseCase.getExploreByLike(new GetExploreDiaryUseCase.Query(page, size));
+            case LATEST -> getExploreDiaryUseCase.getExploreByLatest(new GetExploreDiaryUseCase.Query(userId, page, size));
+            case POPULARITY -> getExploreDiaryUseCase.getExploreByLike(new GetExploreDiaryUseCase.Query(userId, page, size));
         };
 
         return new SliceResponse<>(
                 response.diaries().stream()
-                        .map(diaryInfo -> new DiaryThumbnail(diaryInfo.diaryId(), diaryInfo.mainImageUrl()))
+                        .map(diaryInfo -> new ExploreDiaryResponse(
+                                diaryInfo.diaryId(),
+                                diaryInfo.mainImageUrl(),
+                                diaryInfo.isLiked()))
                         .toList(),
                 response.size(),
                 response.number(),

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/ExploreDiaryResponse.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/ExploreDiaryResponse.java
@@ -1,0 +1,12 @@
+package com.canvas.bootstrap.diary.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ExploreDiaryResponse(
+        @Schema(description = "일기 ID")
+        String diaryId,
+        @Schema(description = "일기 메인 이미지 url")
+        String mainImageUrl,
+        @Schema(description = "좋아요 선택 여부")
+        Boolean isLiked
+) {}

--- a/Domain-Module/src/main/java/com/canvas/domain/diary/entity/DiaryComplete.java
+++ b/Domain-Module/src/main/java/com/canvas/domain/diary/entity/DiaryComplete.java
@@ -100,4 +100,12 @@ public class DiaryComplete {
         return writerId.value().equals(userId.value());
     }
 
+    public String getMainImageOrDefault() {
+        return images.stream()
+                     .filter(Image::isMain)
+                     .map(Image::getImageUrl)
+                     .findFirst()
+                     .orElse(Image.DEFAULT_IMAGE_URL);
+    }
+
 }

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/adapter/DiaryManagementJpaAdapter.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/adapter/DiaryManagementJpaAdapter.java
@@ -116,21 +116,21 @@ public class DiaryManagementJpaAdapter implements DiaryManagementPort {
     }
 
     @Override
-    public Slice<DiaryOverview> getExploreByLatest(PageRequest pageRequest) {
+    public Slice<DiaryComplete> getExploreByLatest(PageRequest pageRequest) {
         var diaryEntities = diaryJpaRepository.findAllByIsPublicTrue(
                 PageMapper.toJpaPageRequest(pageRequest)
         );
 
-        return PageMapper.toDomainSlice(diaryEntities, DiaryMapper::toOverviewDomain);
+        return PageMapper.toDomainSlice(diaryEntities, DiaryMapper::toCompleteDomain);
     }
 
     @Override
-    public Slice<DiaryOverview> getExploreByLike(PageRequest pageRequest) {
+    public Slice<DiaryComplete> getExploreByLike(PageRequest pageRequest) {
         var diaryEntities = diaryJpaRepository.findAllByIsPublicTrueOrderByLikeCountDesc(
                 PageMapper.toJpaPageRequest(pageRequest)
         );
 
-        return PageMapper.toDomainSlice(diaryEntities, DiaryMapper::toOverviewDomain);
+        return PageMapper.toDomainSlice(diaryEntities, DiaryMapper::toCompleteDomain);
     }
 
     @Override


### PR DESCRIPTION
# 이슈
- #84 

# 구현 내용
* [x] 일기 탐색 API 응답 DTO `isLiked` 속성 추가

# 세부 내용
## 일기 탐색 API 응답 DTO `isLiked` 속성 추가
### DiaryManagementPort
```java
Slice<DiaryComplete> getExploreByLatest(PageRequest pageRequest);
Slice<DiaryComplete> getExploreByLike(PageRequest pageRequest);
```
- 좋아요 정보가 필요해 `DiaryOverview` 대신 `DiaryComplete` 반환

### DiaryQueryService
```java
slice.content().stream()
        .map(diary -> new GetExploreDiaryUseCase.Response.DiaryInfo(
                diary.getId().toString(),
                diary.getMainImageOrDefault(),
                diary.isLiked(userId)))
        .toList(),
```
- 각 일기마다 좋아요를 눌렀는지 여부를 반환

close #84 