### PR TITLE
test: 애플리케이션 모듈 테스트 작성

### DIFF
--- a/Application-Module/build.gradle
+++ b/Application-Module/build.gradle
@@ -1,6 +1,11 @@
 dependencies {
     implementation(project(":Domain-Module"))
+    testImplementation(testFixtures(project(":Domain-Module")))
+    testFixturesImplementation(testFixtures(project(":Domain-Module")))
+
     implementation(project(":Common-Module"))
+    testImplementation(testFixtures(project(":Common-Module")))
+    testFixturesImplementation(testFixtures(project(":Common-Module")))
 
     implementation "org.springframework:spring-tx"
 }

--- a/Application-Module/src/main/java/com/canvas/application/image/exception/ImageException.java
+++ b/Application-Module/src/main/java/com/canvas/application/image/exception/ImageException.java
@@ -1,4 +1,4 @@
-package com.canvas.application.image.port.exception;
+package com.canvas.application.image.exception;
 
 import com.canvas.common.exception.BusinessException;
 import org.springframework.http.HttpStatus;

--- a/Application-Module/src/main/java/com/canvas/application/image/service/ImageCommandService.java
+++ b/Application-Module/src/main/java/com/canvas/application/image/service/ImageCommandService.java
@@ -1,7 +1,7 @@
-package com.canvas.application.image.port.service;
+package com.canvas.application.image.service;
 
 import com.canvas.application.diary.port.out.DiaryManagementPort;
-import com.canvas.application.image.port.exception.ImageException;
+import com.canvas.application.image.exception.ImageException;
 import com.canvas.application.image.port.in.AddImageUseCase;
 import com.canvas.application.image.port.in.RemoveImageUseCase;
 import com.canvas.application.image.port.in.SetMainImageUseCase;

--- a/Application-Module/src/main/java/com/canvas/application/like/port/in/AddLikeUseCase.java
+++ b/Application-Module/src/main/java/com/canvas/application/like/port/in/AddLikeUseCase.java
@@ -1,4 +1,4 @@
-package com.canvas.application.like.in;
+package com.canvas.application.like.port.in;
 
 public interface AddLikeUseCase {
     void add(Command command);

--- a/Application-Module/src/main/java/com/canvas/application/like/port/in/CancelLikeUseCase.java
+++ b/Application-Module/src/main/java/com/canvas/application/like/port/in/CancelLikeUseCase.java
@@ -1,4 +1,4 @@
-package com.canvas.application.like.in;
+package com.canvas.application.like.port.in;
 
 public interface CancelLikeUseCase {
     void cancel(Command command);

--- a/Application-Module/src/main/java/com/canvas/application/like/port/out/LikeManagementPort.java
+++ b/Application-Module/src/main/java/com/canvas/application/like/port/out/LikeManagementPort.java
@@ -1,4 +1,4 @@
-package com.canvas.application.like.out;
+package com.canvas.application.like.port.out;
 
 import com.canvas.domain.common.DomainId;
 import com.canvas.domain.diary.entity.Like;

--- a/Application-Module/src/main/java/com/canvas/application/like/service/LikeCommandService.java
+++ b/Application-Module/src/main/java/com/canvas/application/like/service/LikeCommandService.java
@@ -1,8 +1,8 @@
 package com.canvas.application.like.service;
 
-import com.canvas.application.like.in.AddLikeUseCase;
-import com.canvas.application.like.in.CancelLikeUseCase;
-import com.canvas.application.like.out.LikeManagementPort;
+import com.canvas.application.like.port.in.AddLikeUseCase;
+import com.canvas.application.like.port.in.CancelLikeUseCase;
+import com.canvas.application.like.port.out.LikeManagementPort;
 import com.canvas.domain.common.DomainId;
 import com.canvas.domain.diary.entity.Like;
 import lombok.RequiredArgsConstructor;

--- a/Application-Module/src/test/java/com/canvas/application/diary/service/DiaryCommandServiceTest.java
+++ b/Application-Module/src/test/java/com/canvas/application/diary/service/DiaryCommandServiceTest.java
@@ -1,0 +1,181 @@
+package com.canvas.application.diary.service;
+
+import com.canvas.application.diary.exception.DiaryException;
+import com.canvas.application.diary.port.in.AddDiaryUseCase;
+import com.canvas.application.diary.port.in.ModifyDiaryUseCase;
+import com.canvas.application.diary.port.in.RemoveDiaryUseCase;
+import com.canvas.application.diary.port.out.DiaryEmotionExtractPort;
+import com.canvas.application.diary.port.out.DiaryManagementPort;
+import com.canvas.application.image.port.in.AddImageUseCase;
+import com.canvas.domain.common.DomainId;
+import com.canvas.domain.diary.entity.DiaryComplete;
+import com.canvas.domain.diary.entity.Image;
+import com.canvas.domain.diary.enums.Emotion;
+import com.canvas.domain.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static com.canvas.application.diary.DiaryApplicationFixture.*;
+import static com.canvas.domain.fixture.DiaryFixture.PUBLIC_MY_DIARY;
+import static com.canvas.domain.fixture.UserFixture.MYSELF;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class DiaryCommandServiceTest {
+
+    @Mock
+    private DiaryManagementPort diaryManagementPort;
+    @Mock
+    private DiaryEmotionExtractPort diaryEmotionExtractPort;
+    @Mock
+    private AddImageUseCase addImageUseCase;
+
+    @InjectMocks
+    private DiaryCommandService diaryCommandService;
+
+    @Test
+    @DisplayName("일기 생성 성공")
+    void addSuccessTest() {
+        // given
+        User user = MYSELF.getUser();
+        DiaryComplete diary = PUBLIC_MY_DIARY.getDiaryComplete();
+        AddDiaryUseCase.Command command = getAddDiaryCommand(user, diary);
+        String generatedImageUrl = "imageUrl";
+
+        given(diaryManagementPort.existsByWriterIdAndDate(user.getId(), diary.getDate()))
+                .willReturn(false);
+        given(diaryEmotionExtractPort.emotionExtract(command.content()))
+                .willReturn(diary.getEmotion());
+        given(addImageUseCase.create(any(AddImageUseCase.Command.Create.class)))
+                .willReturn(new AddImageUseCase.Response.Create(generatedImageUrl));
+
+        // when
+        AddDiaryUseCase.Response response = diaryCommandService.add(command);
+
+        // then
+        ArgumentCaptor<DiaryComplete> captor = ArgumentCaptor.forClass(DiaryComplete.class);
+        verify(diaryManagementPort).save(captor.capture());
+
+        DiaryComplete savedDiary = captor.getValue();
+        assertThat(savedDiary.getId()).isEqualTo(DomainId.from(response.diaryId()));
+        assertThat(savedDiary.getWriterId()).isEqualTo(diary.getWriterId());
+        assertThat(savedDiary.getContent()).isEqualTo(diary.getContent());
+        assertThat(savedDiary.getEmotion()).isEqualTo(diary.getEmotion());
+        assertThat(savedDiary.getDate()).isEqualTo(diary.getDate());
+        assertThat(savedDiary.getIsPublic()).isEqualTo(diary.getIsPublic());
+        assertThat(savedDiary.getImages())
+                .hasSize(1)
+                .extracting(Image::getImageUrl)
+                .containsExactly(generatedImageUrl);
+    }
+
+    @Test
+    @DisplayName("일기 생성 실패")
+    void addFailureTest() {
+        // given
+        User user = MYSELF.getUser();
+        DiaryComplete diary = PUBLIC_MY_DIARY.getDiaryComplete();
+        AddDiaryUseCase.Command command = getAddDiaryCommand(user, diary);
+
+        given(diaryManagementPort.existsByWriterIdAndDate(user.getId(), diary.getDate()))
+                .willReturn(true);
+
+        // when
+        // then
+        assertThatThrownBy(() -> diaryCommandService.add(command))
+                .isInstanceOf(DiaryException.DiaryBadRequestException.class);
+    }
+
+    @Test
+    @DisplayName("일기 공개 여부만 수정")
+    void modifyPublicTest() {
+        // given
+        User user = MYSELF.getUser();
+        DiaryComplete diary = PUBLIC_MY_DIARY.getDiaryComplete();
+        ModifyDiaryUseCase.Command command = getModifyDiaryCommand(user, diary, diary.getContent(), !diary.getIsPublic());
+
+        given(diaryManagementPort.getByIdAndWriterId(diary.getId(), diary.getWriterId()))
+                .willReturn(diary);
+
+        // when
+        diaryCommandService.modify(command);
+
+        // then
+        verify(diaryEmotionExtractPort, never()).emotionExtract(command.content());
+        verify(diaryManagementPort).save(diary);
+        assertThat(diary.getContent()).isEqualTo(command.content());
+        assertThat(diary.getIsPublic()).isEqualTo(command.isPublic());
+    }
+
+    @Test
+    @DisplayName("일기 내용, 공개 여부 모두 수정")
+    void modifyContentTest() {
+        // given
+        User user = MYSELF.getUser();
+        DiaryComplete diary = PUBLIC_MY_DIARY.getDiaryComplete();
+        String newContent = "새로운 내용";
+        Emotion newEmotion = Emotion.ANGER;
+        ModifyDiaryUseCase.Command command = getModifyDiaryCommand(user, diary, newContent, !diary.getIsPublic());
+
+        given(diaryManagementPort.getByIdAndWriterId(diary.getId(), diary.getWriterId()))
+                .willReturn(diary);
+        given(diaryEmotionExtractPort.emotionExtract(command.content()))
+                .willReturn(newEmotion);
+
+        // when
+        diaryCommandService.modify(command);
+
+        // then
+        verify(diaryEmotionExtractPort).emotionExtract(command.content());
+        verify(diaryManagementPort).save(diary);
+        assertThat(diary.getContent()).isEqualTo(command.content());
+        assertThat(diary.getIsPublic()).isEqualTo(command.isPublic());
+    }
+
+    @Test
+    @DisplayName("일기 삭제 성공")
+    void removeSuccessTest() {
+        // given
+        User user = MYSELF.getUser();
+        DiaryComplete diary = PUBLIC_MY_DIARY.getDiaryComplete();
+        RemoveDiaryUseCase.Command command = getRemoveDiaryCommand(user, diary);
+
+        given(diaryManagementPort.existsByIdAndWriterId(diary.getId(), user.getId()))
+                .willReturn(true);
+
+        // when
+        diaryCommandService.remove(command);
+
+        // then
+        verify(diaryManagementPort).deleteById(diary.getId());
+    }
+
+    @Test
+    @DisplayName("일기 삭제 실패")
+    void removeFailureTest() {
+        // given
+        User user = MYSELF.getUser();
+        DiaryComplete diary = PUBLIC_MY_DIARY.getDiaryComplete();
+        RemoveDiaryUseCase.Command command = getRemoveDiaryCommand(user, diary);
+
+        given(diaryManagementPort.existsByIdAndWriterId(diary.getId(), user.getId()))
+                .willReturn(false);
+
+        // when
+        // then
+        assertThatThrownBy(() -> diaryCommandService.remove(command))
+                .isInstanceOf(DiaryException.DiaryForbiddenException.class);
+        verify(diaryManagementPort, never()).deleteById(diary.getId());
+    }
+
+}

--- a/Application-Module/src/test/java/com/canvas/application/diary/service/DiaryQueryServiceTest.java
+++ b/Application-Module/src/test/java/com/canvas/application/diary/service/DiaryQueryServiceTest.java
@@ -1,0 +1,114 @@
+package com.canvas.application.diary.service;
+
+import com.canvas.application.diary.exception.DiaryException;
+import com.canvas.application.diary.port.in.GetDiaryUseCase;
+import com.canvas.application.diary.port.out.DiaryManagementPort;
+import com.canvas.domain.diary.entity.DiaryBasic;
+import com.canvas.domain.diary.entity.DiaryComplete;
+import com.canvas.domain.fixture.DiaryFixture;
+import com.canvas.domain.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static com.canvas.application.diary.DiaryApplicationFixture.getGetDiaryQuery;
+import static com.canvas.application.diary.DiaryApplicationFixture.getHomeCalendarQuery;
+import static com.canvas.domain.fixture.DiaryFixture.PRIVATE_OTHER_DIARY;
+import static com.canvas.domain.fixture.DiaryFixture.PUBLIC_MY_DIARY;
+import static com.canvas.domain.fixture.UserFixture.MYSELF;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class DiaryQueryServiceTest {
+
+    @Mock
+    private DiaryManagementPort diaryManagementPort;
+
+    @InjectMocks
+    private DiaryQueryService diaryQueryService;
+
+    @Test
+    @DisplayName("일기 단일 조회 성공")
+    void getDiarySuccessTest() {
+        // given
+        User user = MYSELF.getUser();
+        DiaryComplete diary = PUBLIC_MY_DIARY.getDiaryComplete();
+        GetDiaryUseCase.Query.Diary query = getGetDiaryQuery(user, diary);
+
+        given(diaryManagementPort.getById(diary.getId())).willReturn(diary);
+
+        // when
+        GetDiaryUseCase.Response.DiaryInfo response = diaryQueryService.getDiary(query);
+
+        // then
+        assertThat(response.diaryId()).isEqualTo(diary.getId().toString());
+        assertThat(response.content()).isEqualTo(diary.getContent());
+        assertThat(response.emotion()).isEqualTo(diary.getEmotion());
+        assertThat(response.likeCount()).isEqualTo(diary.getLikeCount());
+        assertThat(response.isLiked()).isEqualTo(diary.isLiked(user.getId()));
+        assertThat(response.isMine()).isEqualTo(diary.isWriter(user.getId()));
+        assertThat(response.date()).isEqualTo(diary.getDate());
+        assertThat(response.isPublic()).isEqualTo(diary.getIsPublic());
+        assertThat(response.images()).containsExactlyInAnyOrderElementsOf(diary.getImages().stream()
+                .map(image -> new GetDiaryUseCase.Response.DiaryInfo.ImageInfo(
+                        image.getId().toString(),
+                        image.getIsMain(),
+                        image.getImageUrl()
+                )).toList());
+
+    }
+
+    @Test
+    @DisplayName("일기 단일 조회 실패")
+    void getDiaryFailureTest() {
+        // given
+        User user = MYSELF.getUser();
+        DiaryComplete diary = PRIVATE_OTHER_DIARY.getDiaryComplete();
+        GetDiaryUseCase.Query.Diary query = getGetDiaryQuery(user, diary);
+
+        given(diaryManagementPort.getById(diary.getId())).willReturn(diary);
+
+        // when
+        // then
+        assertThatThrownBy(() -> diaryQueryService.getDiary(query))
+                .isInstanceOf(DiaryException.DiaryForbiddenException.class);
+    }
+
+    @Test
+    @DisplayName("홈 달력 조회")
+    void getHomeCalendarTest() {
+        // given
+        User user = MYSELF.getUser();
+        LocalDate date = LocalDate.now();
+        GetDiaryUseCase.Query.HomeCalendar query = getHomeCalendarQuery(user, date);
+        List<DiaryBasic> diaries = DiaryFixture.getAllDiaryBasicByUser(MYSELF);
+
+        given(diaryManagementPort.getByUserIdAndMonth(user.getId(), date))
+                .willReturn(diaries);
+
+        // when
+        GetDiaryUseCase.Response.HomeCalendar response = diaryQueryService.getHomeCalendar(query);
+
+        // then
+        assertThat(response.diaries())
+                .hasSameSizeAs(diaries)
+                .allSatisfy(diaryInfo -> {
+                    DiaryBasic matchingDiary = diaries.stream()
+                                                      .filter(diary -> diary.getId().toString().equals(diaryInfo.diaryId()))
+                                                      .findFirst()
+                                                      .orElseThrow();
+
+                    assertThat(diaryInfo.date()).isEqualTo(matchingDiary.getDate());
+                    assertThat(diaryInfo.emotion()).isEqualTo(matchingDiary.getEmotion());
+                });
+    }
+
+}

--- a/Application-Module/src/test/java/com/canvas/application/image/service/ImageCommandServiceTest.java
+++ b/Application-Module/src/test/java/com/canvas/application/image/service/ImageCommandServiceTest.java
@@ -1,0 +1,174 @@
+package com.canvas.application.image.service;
+
+import com.canvas.application.diary.port.out.DiaryManagementPort;
+import com.canvas.application.image.exception.ImageException;
+import com.canvas.application.image.port.in.AddImageUseCase;
+import com.canvas.application.image.port.in.RemoveImageUseCase;
+import com.canvas.application.image.port.in.SetMainImageUseCase;
+import com.canvas.application.image.port.out.ImageGenerationPort;
+import com.canvas.application.image.port.out.ImageManagementPort;
+import com.canvas.application.image.port.out.ImagePromptGeneratePort;
+import com.canvas.application.image.port.out.ImageUploadPort;
+import com.canvas.domain.diary.entity.DiaryComplete;
+import com.canvas.domain.diary.entity.DiaryOverview;
+import com.canvas.domain.diary.entity.Image;
+import com.canvas.domain.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static com.canvas.application.image.ImageApplicationFixture.*;
+import static com.canvas.domain.fixture.DiaryFixture.PUBLIC_MY_DIARY;
+import static com.canvas.domain.fixture.ImageFixture.PUBLIC_MY_DIARY_IMAGE2;
+import static com.canvas.domain.fixture.UserFixture.MYSELF;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ImageCommandServiceTest {
+
+    @Mock
+    private DiaryManagementPort diaryManagementPort;
+    @Mock
+    private ImageGenerationPort imageGenerationPort;
+    @Mock
+    private ImageManagementPort imageManagementPort;
+    @Mock
+    private ImagePromptGeneratePort imagePromptGeneratePort;
+    @Mock
+    private ImageUploadPort imageUploadPort;
+
+    @Spy
+    @InjectMocks
+    private ImageCommandService imageCommandService;
+
+    @Test
+    @DisplayName("이미지 추가")
+    void addTest() {
+        // given
+        DiaryComplete diary = PUBLIC_MY_DIARY.getDiaryComplete();
+        Image image = PUBLIC_MY_DIARY_IMAGE2.getImage();
+
+        AddImageUseCase.Command.Add command = getAddImageCommand(diary);
+
+        given(diaryManagementPort.getById(diary.getId())).willReturn(diary);
+        doReturn(new AddImageUseCase.Response.Create(image.getImageUrl())).when(imageCommandService).create(any());
+
+        // when
+        AddImageUseCase.Response.Add response = imageCommandService.add(command);
+
+        // then
+        verify(imageCommandService).create(any(AddImageUseCase.Command.Create.class));
+        verify(imageManagementPort).save(any(Image.class));
+        assertThat(response.isMain()).isFalse();
+        assertThat(response.imageUrl()).isEqualTo(image.getImageUrl());
+    }
+
+    @Test
+    @DisplayName("이미지 생성")
+    void createTest() {
+        // given
+        AddImageUseCase.Command.Create command = getCreateImageCommand();
+
+        given(imagePromptGeneratePort.generatePrompt(command.content())).willReturn("prompt");
+        given(imageGenerationPort.generate("prompt", command.style())).willReturn("generatedImageUrl");
+        given(imageUploadPort.upload("generatedImageUrl")).willReturn("uploadedImageUrl");
+
+        // when
+        AddImageUseCase.Response.Create response = imageCommandService.create(command);
+
+        // then
+        assertThat(response.imageUrl()).isEqualTo("uploadedImageUrl");
+    }
+
+    @Test
+    @DisplayName("이미지 삭제 성공")
+    void removeSuccessTest() {
+        // given
+        User user = MYSELF.getUser();
+        Image image = PUBLIC_MY_DIARY_IMAGE2.getImage();
+        RemoveImageUseCase.Command command = getRemoveImageCommand(user, image);
+
+        given(imageManagementPort.existsByIdAndUserId(image.getId(), user.getId())).willReturn(true);
+
+        // when
+        imageCommandService.remove(command);
+
+        // then
+        verify(imageManagementPort).deleteById(image.getId());
+    }
+
+    @Test
+    @DisplayName("이미지 삭제 실패")
+    void removeFailureTest() {
+        // given
+        User user = MYSELF.getUser();
+        Image image = PUBLIC_MY_DIARY_IMAGE2.getImage();
+        RemoveImageUseCase.Command command = getRemoveImageCommand(user, image);
+
+        given(imageManagementPort.existsByIdAndUserId(image.getId(), user.getId())).willReturn(false);
+
+        // when
+        // then
+        assertThatThrownBy(() -> imageCommandService.remove(command))
+                .isInstanceOf(ImageException.ImageNotFoundException.class);
+        verify(imageManagementPort, never()).deleteById(image.getId());
+    }
+
+    @Test
+    @DisplayName("메인 이미지 변경 성공")
+    void setMainImageSuccessTest() {
+        // given
+        DiaryOverview diary = PUBLIC_MY_DIARY.getDiaryOverview();
+        Image image = PUBLIC_MY_DIARY_IMAGE2.getImage();
+        User user = MYSELF.getUser();
+        SetMainImageUseCase.Command command = getSetMainImageCommand(user, image);
+
+        given(imageManagementPort.getAllInDiaryByIdAndWriterId(image.getId(), diary.getWriterId()))
+                .willReturn(diary.getImages());
+
+        // when
+        imageCommandService.setMain(command);
+
+        // then
+        verify(imageManagementPort).saveAll(diary.getImages());
+        assertThat(diary.getImages())
+                .anySatisfy(img -> {
+                    assertThat(img.getId()).isEqualTo(image.getId());
+                    assertThat(img.isMain()).isTrue();
+                })
+                .allSatisfy(img -> {
+                    if (!img.getId().equals(image.getId())) {
+                        assertThat(img.isMain()).isFalse();
+                    }
+                });
+    }
+
+    @Test
+    @DisplayName("메인 이미지 변경 실패")
+    void setMainFailureTest() {
+        // given
+        DiaryOverview diary = PUBLIC_MY_DIARY.getDiaryOverview();
+        Image image = PUBLIC_MY_DIARY_IMAGE2.getImage();
+        User user = MYSELF.getUser();
+        SetMainImageUseCase.Command command = getSetMainImageCommand(user, image);
+
+        given(imageManagementPort.getAllInDiaryByIdAndWriterId(image.getId(), diary.getWriterId()))
+                .willReturn(List.of());
+
+        // when
+        // then
+        assertThatThrownBy(() -> imageCommandService.setMain(command))
+                .isInstanceOf(ImageException.ImageNotFoundException.class);
+    }
+
+}

--- a/Application-Module/src/test/java/com/canvas/application/like/service/LikeCommandServiceTest.java
+++ b/Application-Module/src/test/java/com/canvas/application/like/service/LikeCommandServiceTest.java
@@ -1,0 +1,62 @@
+package com.canvas.application.like.service;
+
+import com.canvas.application.like.port.in.AddLikeUseCase;
+import com.canvas.application.like.port.in.CancelLikeUseCase;
+import com.canvas.application.like.port.out.LikeManagementPort;
+import com.canvas.domain.diary.entity.DiaryComplete;
+import com.canvas.domain.diary.entity.Like;
+import com.canvas.domain.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static com.canvas.application.like.LikeApplicationFixture.getAddLikeCommand;
+import static com.canvas.application.like.LikeApplicationFixture.getCancelLikeCommand;
+import static com.canvas.domain.fixture.DiaryFixture.PUBLIC_OTHER_DIARY;
+import static com.canvas.domain.fixture.UserFixture.MYSELF;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class LikeCommandServiceTest {
+
+    @Mock
+    private LikeManagementPort likeManagementPort;
+
+    @InjectMocks
+    private LikeCommandService likeCommandService;
+
+    @Test
+    @DisplayName("좋아요 추가")
+    void addTest() {
+        // given
+        User user = MYSELF.getUser();
+        DiaryComplete diary = PUBLIC_OTHER_DIARY.getDiaryComplete();
+        AddLikeUseCase.Command command = getAddLikeCommand(user, diary);
+
+        // when
+        likeCommandService.add(command);
+
+        // then
+        verify(likeManagementPort).add(any(Like.class));
+    }
+
+    @Test
+    @DisplayName("좋아요 취소")
+    void cancelTest() {
+        // given
+        User user = MYSELF.getUser();
+        DiaryComplete diary = PUBLIC_OTHER_DIARY.getDiaryComplete();
+        CancelLikeUseCase.Command command = getCancelLikeCommand(user, diary);
+
+        // when
+        likeCommandService.cancel(command);
+
+        // then
+        verify(likeManagementPort).remove(user.getId(), diary.getId());
+    }
+
+}

--- a/Application-Module/src/testFixtures/java/com/canvas/application/diary/DiaryApplicationFixture.java
+++ b/Application-Module/src/testFixtures/java/com/canvas/application/diary/DiaryApplicationFixture.java
@@ -1,0 +1,103 @@
+package com.canvas.application.diary;
+
+import com.canvas.application.common.enums.Style;
+import com.canvas.application.diary.port.in.*;
+import com.canvas.domain.diary.entity.DiaryComplete;
+import com.canvas.domain.diary.enums.Emotion;
+import com.canvas.domain.user.entity.User;
+
+import java.time.LocalDate;
+
+public class DiaryApplicationFixture {
+    public static AddDiaryUseCase.Command getAddDiaryCommand(User user, DiaryComplete diary) {
+        return new AddDiaryUseCase.Command(
+                user.getId().toString(),
+                diary.getDate(),
+                diary.getContent(),
+                Style.PHOTOREALISTIC,
+                diary.getIsPublic()
+        );
+    }
+
+    public static ModifyDiaryUseCase.Command getModifyDiaryCommand(User user, DiaryComplete diary, String content, Boolean isPublic) {
+        return new ModifyDiaryUseCase.Command(
+                user.getId().toString(),
+                diary.getId().toString(),
+                content,
+                isPublic
+        );
+    }
+
+    public static RemoveDiaryUseCase.Command getRemoveDiaryCommand(User user, DiaryComplete diary) {
+        return new RemoveDiaryUseCase.Command(
+                diary.getId().toString(),
+                user.getId().toString()
+        );
+    }
+
+    public static GetDiaryUseCase.Query.Diary getGetDiaryQuery(User user, DiaryComplete diary) {
+        return new GetDiaryUseCase.Query.Diary(
+                user.getId().toString(),
+                diary.getId().toString()
+        );
+    }
+
+    public static GetDiaryUseCase.Query.HomeCalendar getHomeCalendarQuery(User user, LocalDate date) {
+        return new GetDiaryUseCase.Query.HomeCalendar(
+                user.getId().toString(),
+                date
+        );
+    }
+
+    public static GetDiaryUseCase.Query.LikedDiaries getLikedDiariesQuery(User user) {
+        return new GetDiaryUseCase.Query.LikedDiaries(
+                user.getId().toString(),
+                0,
+                9
+        );
+    }
+
+    public static GetAlbumDiaryUseCase.Query.Recent getAlbumDiariesQuery(User user) {
+        return new GetAlbumDiaryUseCase.Query.Recent(
+                user.getId().toString(),
+                0,
+                9
+        );
+    }
+
+    public static GetAlbumDiaryUseCase.Query.Content getAlbumDiariesByContentQuery(User user, String content) {
+        return new GetAlbumDiaryUseCase.Query.Content(
+                user.getId().toString(),
+                content,
+                0,
+                9
+        );
+    }
+
+    public static GetAlbumDiaryUseCase.Query.Emotion getAlbumDiariesByEmotionQuery(User user, Emotion emotion) {
+        return new GetAlbumDiaryUseCase.Query.Emotion(
+                user.getId().toString(),
+                emotion.name(),
+                0,
+                9
+        );
+    }
+
+    public static GetAlbumDiaryUseCase.Query.All getAlbumDiariesByContentAndEmotionQuery(User user, String content, Emotion emotion) {
+        return new GetAlbumDiaryUseCase.Query.All(
+                user.getId().toString(),
+                content,
+                emotion.name(),
+                0,
+                9
+        );
+    }
+
+    public static GetExploreDiaryUseCase.Query getExploreDiaryQuery(User user) {
+        return new GetExploreDiaryUseCase.Query(
+                user.getId().toString(),
+                0,
+                9
+        );
+    }
+}

--- a/Application-Module/src/testFixtures/java/com/canvas/application/image/ImageApplicationFixture.java
+++ b/Application-Module/src/testFixtures/java/com/canvas/application/image/ImageApplicationFixture.java
@@ -1,0 +1,42 @@
+package com.canvas.application.image;
+
+import com.canvas.application.common.enums.Style;
+import com.canvas.application.image.port.in.AddImageUseCase;
+import com.canvas.application.image.port.in.RemoveImageUseCase;
+import com.canvas.application.image.port.in.SetMainImageUseCase;
+import com.canvas.domain.common.DomainId;
+import com.canvas.domain.diary.entity.DiaryComplete;
+import com.canvas.domain.diary.entity.Image;
+import com.canvas.domain.user.entity.User;
+
+public class ImageApplicationFixture {
+    public static AddImageUseCase.Command.Add getAddImageCommand(DiaryComplete diary) {
+        return new AddImageUseCase.Command.Add(
+                diary.getId().toString(),
+                Style.PHOTOREALISTIC
+        );
+    }
+
+    public static AddImageUseCase.Command.Create getCreateImageCommand() {
+        return new AddImageUseCase.Command.Create(
+                DomainId.generate().toString(),
+                "content",
+                Style.PHOTOREALISTIC
+        );
+    }
+
+    public static RemoveImageUseCase.Command getRemoveImageCommand(User user, Image image) {
+        return new RemoveImageUseCase.Command(
+                user.getId().toString(),
+                image.getDiaryId().toString(),
+                image.getId().toString()
+        );
+    }
+
+    public static SetMainImageUseCase.Command getSetMainImageCommand(User user, Image image) {
+        return new SetMainImageUseCase.Command(
+                user.getId().toString(),
+                image.getId().toString()
+        );
+    }
+}

--- a/Application-Module/src/testFixtures/java/com/canvas/application/like/LikeApplicationFixture.java
+++ b/Application-Module/src/testFixtures/java/com/canvas/application/like/LikeApplicationFixture.java
@@ -1,0 +1,22 @@
+package com.canvas.application.like;
+
+import com.canvas.application.like.port.in.AddLikeUseCase;
+import com.canvas.application.like.port.in.CancelLikeUseCase;
+import com.canvas.domain.diary.entity.DiaryComplete;
+import com.canvas.domain.user.entity.User;
+
+public class LikeApplicationFixture {
+    public static AddLikeUseCase.Command getAddLikeCommand(User user, DiaryComplete diaryComplete) {
+        return new AddLikeUseCase.Command(
+                user.getId().toString(),
+                diaryComplete.getId().toString()
+        );
+    }
+
+    public static CancelLikeUseCase.Command getCancelLikeCommand(User user, DiaryComplete diaryComplete) {
+        return new CancelLikeUseCase.Command(
+                user.getId().toString(),
+                diaryComplete.getId().toString()
+        );
+    }
+}

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/like/controller/LikeController.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/like/controller/LikeController.java
@@ -1,7 +1,7 @@
 package com.canvas.bootstrap.like.controller;
 
-import com.canvas.application.like.in.AddLikeUseCase;
-import com.canvas.application.like.in.CancelLikeUseCase;
+import com.canvas.application.like.port.in.AddLikeUseCase;
+import com.canvas.application.like.port.in.CancelLikeUseCase;
 import com.canvas.application.like.service.LikeCommandService;
 import com.canvas.bootstrap.like.api.LikeApi;
 import lombok.RequiredArgsConstructor;

--- a/Common-Module/src/testFixtures/java/com/canvas/command/page/PageRequestFixture.java
+++ b/Common-Module/src/testFixtures/java/com/canvas/command/page/PageRequestFixture.java
@@ -1,0 +1,10 @@
+package com.canvas.command.page;
+
+import com.canvas.common.page.PageRequest;
+import com.canvas.common.page.Sort;
+
+public class PageRequestFixture {
+    public static PageRequest getPageRequest() {
+        return new PageRequest(1, 9, Sort.by(Sort.Direction.DESC, "createdAt"));
+    }
+}

--- a/Domain-Module/src/testFixtures/java/com/canvas/domain/fixture/DiaryFixture.java
+++ b/Domain-Module/src/testFixtures/java/com/canvas/domain/fixture/DiaryFixture.java
@@ -13,6 +13,7 @@ import lombok.Getter;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.List;
 
 import static com.canvas.domain.diary.enums.Emotion.*;
 import static com.canvas.domain.fixture.UserFixture.*;
@@ -126,5 +127,20 @@ public enum DiaryFixture {
                                 .map(LikeFixture::getLike)
                                 .toList())
                 .build();
+    }
+
+    public static List<DiaryBasic> getAllDiaryBasicByUser(UserFixture userFixture) {
+        return Arrays.stream(DiaryFixture.values())
+                .filter(diaryFixture -> diaryFixture.userFixture.equals(userFixture))
+                .map(DiaryFixture::getDiaryBasie)
+                .toList();
+    }
+
+    public static List<DiaryOverview> getLikedDiaries(UserFixture userFixture) {
+        return Arrays.stream(LikeFixture.values())
+                .filter(likeFixture -> likeFixture.getUserFixture().equals(userFixture))
+                .map(LikeFixture::getDiaryFixture)
+                .map(DiaryFixture::getDiaryOverview)
+                .toList();
     }
 }

--- a/Domain-Module/src/testFixtures/java/com/canvas/domain/fixture/LikeFixture.java
+++ b/Domain-Module/src/testFixtures/java/com/canvas/domain/fixture/LikeFixture.java
@@ -16,6 +16,7 @@ public enum LikeFixture {
     PUBLIC_OTHER_DIARY_LIKE2(OTHER2, PUBLIC_OTHER_DIARY);
 
     private final DomainId id;
+    @Getter
     private final UserFixture userFixture;
     @Getter
     private final DiaryFixture diaryFixture;

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/adapter/LikeManagementJpaAdapter.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/adapter/LikeManagementJpaAdapter.java
@@ -1,7 +1,7 @@
 package com.canvas.persistence.jpa.diary.adapter;
 
 import com.canvas.application.like.exception.LikeException;
-import com.canvas.application.like.out.LikeManagementPort;
+import com.canvas.application.like.port.out.LikeManagementPort;
 import com.canvas.domain.common.DomainId;
 import com.canvas.domain.diary.entity.Like;
 import com.canvas.persistence.jpa.diary.LikeMapper;


### PR DESCRIPTION
# 구현 내용
* [x] 애플리케이션 모듈 테스트 작성
* [x] 애플리케이션 모듈 구조에 맞게 패키지 이동

# 세부 내용
## 애플리케이션 모듈 테스트 작성
- `UseCase` 픽스처 생성
- `Service` 테스트 작성

# 고민한 내용
## `@Spy`를 붙인 클래스에 `any()`를 설정한 메소드 호출 시 매개변수에 `null`이 들어가 `NullPointerException`이 발생
- `@Spy`로 모킹한 메소드는 `@Mock`과 달리 실제로 실행
- 구체적인 값을 설정하면 `NullPointerException`은 발생하지 않음
- `when(...).thenReturn(...)` 대신 `doReturn(...).when(...)`을 사용해 해결
  - `when(...).thenReturn(...)`은 메소드의 실제 호출이 이루어진 후 스터빙이 설정
  - `doReturn(...).when(...)`은 메소드를 호출하지 않고 스터빙 값을 바로 결정