### PR TITLE
feat: 외부 API 응답 예외 처리

### DIFF
--- a/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/DiaryContentConvertGeminiAdapter.java
+++ b/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/DiaryContentConvertGeminiAdapter.java
@@ -20,7 +20,6 @@ public class DiaryContentConvertGeminiAdapter
     @Override
     public Emotion emotionExtract(String content) {
         String emotion = geminiService.generate(GeminiPromptConsts.EMOTION_EXTRACT + content);
-        log.info("emotion={}", emotion);
         return Emotion.parse(emotion);
     }
 

--- a/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/exception/GeminiException.java
+++ b/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/exception/GeminiException.java
@@ -1,19 +1,33 @@
 package com.canvas.google.gemini.exception;
 
-// TODO - 공통 커스텀 예외로 리팩토링 필요
-public class GeminiException extends IllegalArgumentException {
+import com.canvas.common.exception.BusinessException;
+import org.springframework.http.HttpStatus;
 
-    public GeminiException(String s) {
-        super(s);
+public class GeminiException extends BusinessException {
+
+    private static final String CODE_PREFIX = "GEMINI";
+    private static final String DEFAULT_MESSAGE = "Gemini 예외가 발생했습니다.";
+    private static final HttpStatus DEFAULT_HTTP_STATUS = HttpStatus.BAD_REQUEST;
+
+    public GeminiException() {
+        super(CODE_PREFIX, 0, DEFAULT_HTTP_STATUS, DEFAULT_MESSAGE);
+    }
+
+    public GeminiException(int errorCode, HttpStatus httpStatus, String message) {
+        super(CODE_PREFIX, errorCode, httpStatus, message);
     }
 
     public static class GeminiSafetyException extends GeminiException {
         public GeminiSafetyException() {
-            super("유해한 프롬프트");
-        }
-
-        public GeminiSafetyException(String s) {
-            super(s);
+            super(1, HttpStatus.BAD_REQUEST, "유해한 내용입니다.");
         }
     }
+
+    public static class GeminiTooManyRequestsException extends GeminiException {
+        public GeminiTooManyRequestsException() {
+            super(2, HttpStatus.TOO_MANY_REQUESTS, "요청이 너무 많습니다.");
+        }
+    }
+
+
 }

--- a/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/service/GeminiPromptConsts.java
+++ b/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/service/GeminiPromptConsts.java
@@ -2,14 +2,12 @@ package com.canvas.google.gemini.service;
 
 public class GeminiPromptConsts {
     public static final String IMAGE_GENERATOR = """
-            다음 일기 내용에서 유해하지 않은 가장 중요한 장면을 하나만 정하고, 그 주요 장면을 구체적으로 설명하는 문장을
-            이미지 생성형 AI의 프롬프트에 적합하게 만들어. 제목은 출력하지 말고 그 프롬프트 내용만 영문으로 출력해.
+            Choose only one of the most important scenes in the following content, and make a sentence that specifically describes the main scene suitable for the prompt in the image Generative AI. If the contents are inappropriate, print FORBIDDEN. Don't print the title, just print the contents of the prompt in English.
             
             """;
 
     public static final String EMOTION_EXTRACT = """
-            다음 일기 내용에서 가장 주된 감정을 ANGER, SADNESS, JOY, FEAR, DISGUST, SHAME, SURPRISE, CURIOSITY
-            중 하나만 골라서 한 단어로만 출력해. 감정이 잘 드러나지 않거나 목록에 없다면 NONE을 출력해.
+            Choose one of ANGER, SADNESS, JOY, FEAR, DISGUST, SHAME, SURPRISE, CURIOSITY, and print out the main emotions in the following diary contents in just one word. If the contents are inappropriate, print FORBIDDEN, and if the emotions are not clearly visible or listed, print NONE.
             
             """;
 }

--- a/Infrastructure-Module/ImageGenerator/src/main/java/com/canvas/generator/flux/exception/FluxException.java
+++ b/Infrastructure-Module/ImageGenerator/src/main/java/com/canvas/generator/flux/exception/FluxException.java
@@ -1,0 +1,49 @@
+package com.canvas.generator.flux.exception;
+
+import com.canvas.common.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class FluxException extends BusinessException {
+
+    private static final String CODE_PREFIX = "FLUX";
+    private static final String DEFAULT_MESSAGE = "Flux 예외가 발생했습니다.";
+    private static final HttpStatus DEFAULT_HTTP_STATUS = HttpStatus.BAD_REQUEST;
+
+    public FluxException() {
+        super(CODE_PREFIX, 0, DEFAULT_HTTP_STATUS, DEFAULT_MESSAGE);
+    }
+
+    public FluxException(int errorCode, HttpStatus httpStatus, String message) {
+        super(CODE_PREFIX, errorCode, httpStatus, message);
+    }
+
+    public static class FluxPendingException extends FluxException {
+        public FluxPendingException() {
+            super(1, HttpStatus.BAD_REQUEST, "보류 중입니다.");
+        }
+    }
+
+    public static class FluxTaskNotFoundException extends FluxException {
+        public FluxTaskNotFoundException() {
+            super(2, HttpStatus.NOT_FOUND, "작업을 찾을 수 없습니다.");
+        }
+    }
+
+    public static class FluxRequestModeratedException extends FluxException {
+        public FluxRequestModeratedException() {
+            super(3, HttpStatus.BAD_REQUEST, "요청이 검열되었습니다.");
+        }
+    }
+
+    public static class FluxContentModeratedException extends FluxException {
+        public FluxContentModeratedException() {
+            super(4, HttpStatus.BAD_REQUEST, "생성된 콘텐츠가 검열되었습니다.");
+        }
+    }
+
+    public static class FluxErrorException extends FluxException {
+        public FluxErrorException() {
+            super(5, HttpStatus.BAD_REQUEST, "알 수 없는 예외가 발생했습니다.");
+        }
+    }
+}

--- a/Infrastructure-Module/ImageGenerator/src/main/java/com/canvas/generator/flux/exception/FluxResultStatus.java
+++ b/Infrastructure-Module/ImageGenerator/src/main/java/com/canvas/generator/flux/exception/FluxResultStatus.java
@@ -1,0 +1,55 @@
+package com.canvas.generator.flux.exception;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum FluxResultStatus {
+    TASK_NOT_FOUND("Task not found") {
+        @Override
+        public void validate() {
+            throw new FluxException.FluxTaskNotFoundException();
+        }
+    },
+    PENDING("Pending") {
+        @Override
+        public void validate() {
+            throw new FluxException.FluxPendingException();
+        }
+    },
+    REQUEST_MODERATED("Request Moderated") {
+        @Override
+        public void validate() {
+            throw new FluxException.FluxRequestModeratedException();
+        }
+    },
+    CONTENT_MODERATED("Content Moderated") {
+        @Override
+        public void validate() {
+            throw new FluxException.FluxContentModeratedException();
+        }
+    },
+    READY("Ready") {
+        @Override
+        public void validate() {
+
+        }
+    },
+    ERROR("Error") {
+        @Override
+        public void validate() {
+            throw new FluxException.FluxErrorException();
+        }
+    };
+
+    private final String value;
+    public abstract void validate();
+
+    public static FluxResultStatus parse(String value) {
+        for (FluxResultStatus status : values()) {
+            if (status.value.equals(value)) {
+                return status;
+            }
+        }
+        throw new IllegalArgumentException("Unknown status: " + value);
+    }
+}


### PR DESCRIPTION
# 이슈
- #75 

# 구현한 내용
* [x] Gemini API 예외 처리
* [x] Flux API 예외 처리

# 세부 내용
## Gemini API 예외 처리
### GeminiService
```java
.onStatus(status -> status.isSameCodeAs(HttpStatusCode.valueOf(429)), response -> {
    throw new GeminiException.GeminiTooManyRequestsException();
})
```
- 응답 상태 코드가 429면 `GeminiTooManyRequestsException`을 던지고 
```java
.retryWhen(
         Retry.fixedDelay(3, Duration.ofSeconds(3))
                .filter(throwable -> throwable instanceof GeminiException.GeminiTooManyRequestsException))
```
- 3초마다 최대 3번까지 재요청을 한다
```java
.doOnError(error -> new GeminiException.GeminiTooManyRequestsException())
```
- 그래도 정상 응답을 받는 데 실패하면 `GeminiTooManyRequestsException`을 던진다.
```java
.map(response -> {
    if (response.candidates == null || response.isUnhealthy() || response.getText().startsWith("FORBIDDEN")) {
        throw new GeminiException.GeminiSafetyException();
    }
    return response;
})
```
- 응답의 `candidates` 필드가 `null`이거나, `finishReason`이 `SAFETY`이거나 `text`가 `FORBIDDEN`으로 시작하면 `GeminiSafetyException`을 던진다.

## Flux API 예외 처리
### FluxResultStatus
```java
TASK_NOT_FOUND("Task not found") {
    @Override
    public void validate() {
        throw new FluxException.FluxTaskNotFoundException();
    }
},
...
```
- Flux 결과 요청 시 응답 상태마다 던지는 예외를 설정

### FluxClient
```java
.map(response -> {
    FluxResultStatus.parse(response.status).validate();
    return response;
})
```
- 응답 상태에 따라 다른 예외를 던짐
```java
.retryWhen(
        Retry.fixedDelay(3, Duration.ofSeconds(1))
                .filter(throwable -> throwable instanceof FluxException.FluxPendingException))
```
- `FluxPendingException`이면 1초마다 최대 3번까지 재시도

# 참고한 글
- [spring webflux의 webclient 사용할 때 예외 핸들링 및 재 요청 샘플](https://blog.eomsh.com/212)