### PR TITLE
feat: 회고 기능 일부 구현

### DIFF
--- a/Application-Module/src/main/java/com/canvas/application/diary/port/in/GetReminiscenceDiaryUseCase.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/port/in/GetReminiscenceDiaryUseCase.java
@@ -1,0 +1,39 @@
+package com.canvas.application.diary.port.in;
+
+import com.canvas.domain.diary.enums.Emotion;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface GetReminiscenceDiaryUseCase {
+    Response getReminiscenceDiary(Query query);
+
+    record Query (
+            String userId,
+            String content,
+            LocalDate date
+    ){
+
+    }
+
+    record Response (
+        String diaryId,
+        String content,
+        Emotion emotion,
+        Integer likedCount,
+        Boolean isLiked,
+        LocalDate date,
+        List<ImageInfo> images,
+        List<String> keywords
+        ) {
+
+        public record ImageInfo(
+                String imageId,
+                Boolean isMain,
+                String imageUrl
+        ) {}
+    }
+
+
+
+}

--- a/Application-Module/src/main/java/com/canvas/application/diary/port/out/DiaryKeywordExtractPort.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/port/out/DiaryKeywordExtractPort.java
@@ -1,0 +1,7 @@
+package com.canvas.application.diary.port.out;
+
+import java.util.List;
+
+public interface DiaryKeywordExtractPort {
+    List<String> keywordExtract(String content);
+}

--- a/Application-Module/src/main/java/com/canvas/application/diary/port/out/DiaryManagementPort.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/port/out/DiaryManagementPort.java
@@ -25,5 +25,6 @@ public interface DiaryManagementPort {
     Slice<DiaryComplete> getExploreByLatest(PageRequest pageRequest);
     Slice<DiaryComplete> getExploreByLike(PageRequest pageRequest);
     Slice<DiaryOverview> getLikedDiaries(PageRequest pageRequest, DomainId userId);
+    List<DiaryComplete> getByWriteIdAndKeywords(DomainId userId, List<String> keywords);
     void deleteById(DomainId diaryId);
 }

--- a/Application-Module/src/main/java/com/canvas/application/diary/port/out/DiaryManagementPort.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/port/out/DiaryManagementPort.java
@@ -25,6 +25,6 @@ public interface DiaryManagementPort {
     Slice<DiaryComplete> getExploreByLatest(PageRequest pageRequest);
     Slice<DiaryComplete> getExploreByLike(PageRequest pageRequest);
     Slice<DiaryOverview> getLikedDiaries(PageRequest pageRequest, DomainId userId);
-    List<DiaryComplete> getByWriteIdAndKeywords(DomainId userId, List<String> keywords);
+    List<DiaryComplete> getByWriterIdAndKeywords(DomainId userId, List<String> keywords);
     void deleteById(DomainId diaryId);
 }

--- a/Application-Module/src/main/java/com/canvas/application/diary/service/DiaryQueryService.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/service/DiaryQueryService.java
@@ -189,7 +189,7 @@ public class DiaryQueryService
 
         List<String> keywords = diaryKeywordExtractPort.keywordExtract(query.content());
 
-        List<DiaryComplete> diaries = diaryManagementPort.getByWriteIdAndKeywords(userId, keywords);
+        List<DiaryComplete> diaries = diaryManagementPort.getByWriterIdAndKeywords(userId, keywords);
 
         DiaryComplete reminiscenceDiary = findDiaryForReminiscence(diaries);
 

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/api/DiaryApi.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/api/DiaryApi.java
@@ -164,4 +164,18 @@ public interface DiaryApi {
             @RequestParam Integer page,
             @RequestParam Integer size
     );
+
+    @Operation(summary = "회고 일기 조회")
+    @PostMapping("/reminiscence")
+    ReminiscenceResponse getReminiscenceDiary(
+            @AccessUser String userId, @RequestBody ReminiscenceRequest request
+    );
+
+    @Operation(summary = "키워드 저장")
+    @PostMapping("/{diaryId}/reminiscence")
+    void saveKeyword(
+            @AccessUser String userId,
+            @PathVariable String diaryId,
+            @RequestBody SaveKeywordRequest request
+    );
 }

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/controller/DiaryController.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/controller/DiaryController.java
@@ -20,6 +20,7 @@ public class DiaryController implements DiaryApi {
     private final GetExploreDiaryUseCase getExploreDiaryUseCase;
     private final ModifyDiaryUseCase modifyDiaryUseCase;
     private final RemoveDiaryUseCase removeDiaryUseCase;
+    private final GetReminiscenceDiaryUseCase getReminiscenceDiaryUseCase;
 
     @Override
     public CreateDiaryResponse createDiary(String userId, CreateDiaryRequest request) {
@@ -162,8 +163,25 @@ public class DiaryController implements DiaryApi {
 
     @Override
     public ReminiscenceResponse getReminiscenceDiary(String userId, ReminiscenceRequest request) {
+        GetReminiscenceDiaryUseCase.Response response = getReminiscenceDiaryUseCase.getReminiscenceDiary(
+                new GetReminiscenceDiaryUseCase.Query(
+                    userId,
+                    request.content(),
+                    request.date()
+        ));
 
-        return null;
+        return new ReminiscenceResponse(
+                response.diaryId(),
+                response.content(),
+                response.emotion(),
+                response.likedCount(),
+                response.isLiked(),
+                response.date(),
+                response.images().stream()
+                        .map(image -> new ReminiscenceResponse.ImageInfo(image.imageId(), image.isMain(), image.imageUrl()))
+                        .toList(),
+                response.keywords()
+        );
     }
 
     @Override

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/controller/DiaryController.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/controller/DiaryController.java
@@ -160,4 +160,15 @@ public class DiaryController implements DiaryApi {
         );
     }
 
+    @Override
+    public ReminiscenceResponse getReminiscenceDiary(String userId, ReminiscenceRequest request) {
+
+        return null;
+    }
+
+    @Override
+    public void saveKeyword(String userId, String diaryId, SaveKeywordRequest request) {
+
+    }
+
 }

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/ReminiscenceRequest.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/ReminiscenceRequest.java
@@ -1,0 +1,14 @@
+package com.canvas.bootstrap.diary.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+
+@Schema(description = "과거 일기 조히 요청")
+public record ReminiscenceRequest(
+        @Schema(description = "일기 내용")
+        String content,
+        @Schema(description = "일기 날짜")
+        LocalDate date
+) {
+}

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/ReminiscenceResponse.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/ReminiscenceResponse.java
@@ -21,7 +21,10 @@ public record ReminiscenceResponse(
         @Schema(description = "과거 일기 생성 날짜")
         LocalDate date,
         @Schema(description = "과거 일기의 이미지 정보 리스트")
-        List<ReminiscenceResponse.ImageInfo> images) {
+        List<ReminiscenceResponse.ImageInfo> images,
+        @Schema(description = "추출된 키워드 리스트")
+        List<String> keywords
+    ) {
     @Schema(description = "일기의 이미지 정보")
     public record ImageInfo(
             @Schema(description = "이미지 ID")

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/ReminiscenceResponse.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/ReminiscenceResponse.java
@@ -6,7 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import java.util.List;
 
-@Schema(description = "과거 일기 조히 응답")
+@Schema(description = "과거 일기 조회 응답")
 public record ReminiscenceResponse(
         @Schema(description = "과거 일기 ID")
         String diaryId,

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/ReminiscenceResponse.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/ReminiscenceResponse.java
@@ -1,0 +1,35 @@
+package com.canvas.bootstrap.diary.dto;
+
+import com.canvas.domain.diary.enums.Emotion;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Schema(description = "과거 일기 조히 응답")
+public record ReminiscenceResponse(
+        @Schema(description = "과거 일기 ID")
+        String diaryId,
+        @Schema(description = "과거 일기 내용")
+        String content,
+        @Schema(description = "과거 일기의 감정")
+        Emotion emotion,
+        @Schema(description = "과거 일기 좋아요 수")
+        Integer likedCount,
+        @Schema(description = "과거 일기 좋아요 선택 여부")
+        Boolean isLiked,
+        @Schema(description = "과거 일기 생성 날짜")
+        LocalDate date,
+        @Schema(description = "과거 일기의 이미지 정보 리스트")
+        List<ReminiscenceResponse.ImageInfo> images) {
+    @Schema(description = "일기의 이미지 정보")
+    public record ImageInfo(
+            @Schema(description = "이미지 ID")
+            String imageId,
+            @Schema(description = "대표 이미지 여부")
+            Boolean isMain,
+            @Schema(description = "저장된 일기 이미지 url")
+            String imageUrl
+    ) {
+    }
+}

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/SaveKeywordRequest.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/SaveKeywordRequest.java
@@ -2,14 +2,11 @@ package com.canvas.bootstrap.diary.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-import java.time.LocalDate;
 import java.util.List;
 
 @Schema(description = "키워드 저장 요청")
 public record SaveKeywordRequest(
         @Schema(description = "저장할 키워드 리스트")
-        List<String> keywords,
-        @Schema(description = "일기 날짜")
-        LocalDate date
+        List<String> keywords
 ) {
 }

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/SaveKeywordRequest.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/SaveKeywordRequest.java
@@ -1,0 +1,15 @@
+package com.canvas.bootstrap.diary.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Schema(description = "키워드 저장 요청")
+public record SaveKeywordRequest(
+        @Schema(description = "저장할 키워드 리스트")
+        List<String> keywords,
+        @Schema(description = "일기 날짜")
+        LocalDate date
+) {
+}

--- a/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/DiaryContentConvertGeminiAdapter.java
+++ b/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/DiaryContentConvertGeminiAdapter.java
@@ -1,6 +1,7 @@
 package com.canvas.google.gemini;
 
 import com.canvas.application.diary.port.out.DiaryEmotionExtractPort;
+import com.canvas.application.diary.port.out.DiaryKeywordExtractPort;
 import com.canvas.application.image.port.out.ImagePromptGeneratePort;
 import com.canvas.domain.diary.enums.Emotion;
 import com.canvas.google.gemini.service.GeminiPromptConsts;
@@ -9,11 +10,14 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.util.Arrays;
+import java.util.List;
+
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class DiaryContentConvertGeminiAdapter
-        implements DiaryEmotionExtractPort, ImagePromptGeneratePort {
+        implements DiaryEmotionExtractPort, ImagePromptGeneratePort, DiaryKeywordExtractPort {
 
     private final GeminiService geminiService;
 
@@ -26,5 +30,11 @@ public class DiaryContentConvertGeminiAdapter
     @Override
     public String generatePrompt(String content) {
         return geminiService.generate(GeminiPromptConsts.IMAGE_GENERATOR + content);
+    }
+
+    @Override
+    public List<String> keywordExtract(String content) {
+        String response = geminiService.generate(GeminiPromptConsts.KEYWORD_EXTRACT + content);
+        return Arrays.stream(response.split(", ")).toList();
     }
 }

--- a/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/DiaryContentConvertGeminiAdapter.java
+++ b/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/DiaryContentConvertGeminiAdapter.java
@@ -20,7 +20,6 @@ public class DiaryContentConvertGeminiAdapter
     @Override
     public Emotion emotionExtract(String content) {
         String emotion = geminiService.generate(GeminiPromptConsts.EMOTION_EXTRACT + content);
-        log.info("emotion={}", emotion);
         return Emotion.parse(emotion);
     }
 

--- a/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/exception/GeminiException.java
+++ b/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/exception/GeminiException.java
@@ -1,19 +1,33 @@
 package com.canvas.google.gemini.exception;
 
-// TODO - 공통 커스텀 예외로 리팩토링 필요
-public class GeminiException extends IllegalArgumentException {
+import com.canvas.common.exception.BusinessException;
+import org.springframework.http.HttpStatus;
 
-    public GeminiException(String s) {
-        super(s);
+public class GeminiException extends BusinessException {
+
+    private static final String CODE_PREFIX = "GEMINI";
+    private static final String DEFAULT_MESSAGE = "Gemini 예외가 발생했습니다.";
+    private static final HttpStatus DEFAULT_HTTP_STATUS = HttpStatus.BAD_REQUEST;
+
+    public GeminiException() {
+        super(CODE_PREFIX, 0, DEFAULT_HTTP_STATUS, DEFAULT_MESSAGE);
+    }
+
+    public GeminiException(int errorCode, HttpStatus httpStatus, String message) {
+        super(CODE_PREFIX, errorCode, httpStatus, message);
     }
 
     public static class GeminiSafetyException extends GeminiException {
         public GeminiSafetyException() {
-            super("유해한 프롬프트");
-        }
-
-        public GeminiSafetyException(String s) {
-            super(s);
+            super(1, HttpStatus.BAD_REQUEST, "유해한 내용입니다.");
         }
     }
+
+    public static class GeminiTooManyRequestsException extends GeminiException {
+        public GeminiTooManyRequestsException() {
+            super(2, HttpStatus.TOO_MANY_REQUESTS, "요청이 너무 많습니다.");
+        }
+    }
+
+
 }

--- a/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/service/GeminiPromptConsts.java
+++ b/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/service/GeminiPromptConsts.java
@@ -2,14 +2,12 @@ package com.canvas.google.gemini.service;
 
 public class GeminiPromptConsts {
     public static final String IMAGE_GENERATOR = """
-            다음 일기 내용에서 유해하지 않은 가장 중요한 장면을 하나만 정하고, 그 주요 장면을 구체적으로 설명하는 문장을
-            이미지 생성형 AI의 프롬프트에 적합하게 만들어. 제목은 출력하지 말고 그 프롬프트 내용만 영문으로 출력해.
+            Choose only one of the most important scenes in the following content, and make a sentence that specifically describes the main scene suitable for the prompt in the image Generative AI. If the contents are inappropriate, print FORBIDDEN. Don't print the title, just print the contents of the prompt in English.
             
             """;
 
     public static final String EMOTION_EXTRACT = """
-            다음 일기 내용에서 가장 주된 감정을 ANGER, SADNESS, JOY, FEAR, DISGUST, SHAME, SURPRISE, CURIOSITY
-            중 하나만 골라서 한 단어로만 출력해. 감정이 잘 드러나지 않거나 목록에 없다면 NONE을 출력해.
+            Choose one of ANGER, SADNESS, JOY, FEAR, DISGUST, SHAME, SURPRISE, CURIOSITY, and print out the main emotions in the following diary contents in just one word. If the contents are inappropriate, print FORBIDDEN, and if the emotions are not clearly visible or listed, print NONE.
             
             """;
 }

--- a/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/service/GeminiPromptConsts.java
+++ b/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/service/GeminiPromptConsts.java
@@ -10,4 +10,8 @@ public class GeminiPromptConsts {
             Choose one of ANGER, SADNESS, JOY, FEAR, DISGUST, SHAME, SURPRISE, CURIOSITY, and print out the main emotions in the following diary contents in just one word. If the contents are inappropriate, print FORBIDDEN, and if the emotions are not clearly visible or listed, print NONE.
             
             """;
+
+    public static final String KEYWORD_EXTRACT = """
+            일기에서 가장 핵심적인 키워드를 1~5개를 뽑아줘. 정확히 이 형식에 맞춰 뽑아줘 "keyword1, keyword2, keyword3, keyword4, keyword5"
+            """;
 }

--- a/Infrastructure-Module/ImageGenerator/src/main/java/com/canvas/generator/flux/exception/FluxException.java
+++ b/Infrastructure-Module/ImageGenerator/src/main/java/com/canvas/generator/flux/exception/FluxException.java
@@ -1,0 +1,49 @@
+package com.canvas.generator.flux.exception;
+
+import com.canvas.common.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class FluxException extends BusinessException {
+
+    private static final String CODE_PREFIX = "FLUX";
+    private static final String DEFAULT_MESSAGE = "Flux 예외가 발생했습니다.";
+    private static final HttpStatus DEFAULT_HTTP_STATUS = HttpStatus.BAD_REQUEST;
+
+    public FluxException() {
+        super(CODE_PREFIX, 0, DEFAULT_HTTP_STATUS, DEFAULT_MESSAGE);
+    }
+
+    public FluxException(int errorCode, HttpStatus httpStatus, String message) {
+        super(CODE_PREFIX, errorCode, httpStatus, message);
+    }
+
+    public static class FluxPendingException extends FluxException {
+        public FluxPendingException() {
+            super(1, HttpStatus.BAD_REQUEST, "보류 중입니다.");
+        }
+    }
+
+    public static class FluxTaskNotFoundException extends FluxException {
+        public FluxTaskNotFoundException() {
+            super(2, HttpStatus.NOT_FOUND, "작업을 찾을 수 없습니다.");
+        }
+    }
+
+    public static class FluxRequestModeratedException extends FluxException {
+        public FluxRequestModeratedException() {
+            super(3, HttpStatus.BAD_REQUEST, "요청이 검열되었습니다.");
+        }
+    }
+
+    public static class FluxContentModeratedException extends FluxException {
+        public FluxContentModeratedException() {
+            super(4, HttpStatus.BAD_REQUEST, "생성된 콘텐츠가 검열되었습니다.");
+        }
+    }
+
+    public static class FluxErrorException extends FluxException {
+        public FluxErrorException() {
+            super(5, HttpStatus.BAD_REQUEST, "알 수 없는 예외가 발생했습니다.");
+        }
+    }
+}

--- a/Infrastructure-Module/ImageGenerator/src/main/java/com/canvas/generator/flux/exception/FluxResultStatus.java
+++ b/Infrastructure-Module/ImageGenerator/src/main/java/com/canvas/generator/flux/exception/FluxResultStatus.java
@@ -1,0 +1,55 @@
+package com.canvas.generator.flux.exception;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum FluxResultStatus {
+    TASK_NOT_FOUND("Task not found") {
+        @Override
+        public void validate() {
+            throw new FluxException.FluxTaskNotFoundException();
+        }
+    },
+    PENDING("Pending") {
+        @Override
+        public void validate() {
+            throw new FluxException.FluxPendingException();
+        }
+    },
+    REQUEST_MODERATED("Request Moderated") {
+        @Override
+        public void validate() {
+            throw new FluxException.FluxRequestModeratedException();
+        }
+    },
+    CONTENT_MODERATED("Content Moderated") {
+        @Override
+        public void validate() {
+            throw new FluxException.FluxContentModeratedException();
+        }
+    },
+    READY("Ready") {
+        @Override
+        public void validate() {
+
+        }
+    },
+    ERROR("Error") {
+        @Override
+        public void validate() {
+            throw new FluxException.FluxErrorException();
+        }
+    };
+
+    private final String value;
+    public abstract void validate();
+
+    public static FluxResultStatus parse(String value) {
+        for (FluxResultStatus status : values()) {
+            if (status.value.equals(value)) {
+                return status;
+            }
+        }
+        throw new IllegalArgumentException("Unknown status: " + value);
+    }
+}

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/adapter/DiaryManagementJpaAdapter.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/adapter/DiaryManagementJpaAdapter.java
@@ -144,6 +144,14 @@ public class DiaryManagementJpaAdapter implements DiaryManagementPort {
     }
 
     @Override
+    public List<DiaryComplete> getByWriteIdAndKeywords(DomainId userId, List<String> keywords) {
+        List<DiaryEntity> diaryEntities = diaryJpaRepository.findByWriterIdAndKeywords(userId.value(), keywords);
+        return diaryEntities.stream()
+                .map(DiaryMapper::toCompleteDomain)
+                .toList();
+    }
+
+    @Override
     public void deleteById(DomainId diaryId) {
         diaryJpaRepository.deleteById(diaryId.value());
     }

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/adapter/DiaryManagementJpaAdapter.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/adapter/DiaryManagementJpaAdapter.java
@@ -144,7 +144,7 @@ public class DiaryManagementJpaAdapter implements DiaryManagementPort {
     }
 
     @Override
-    public List<DiaryComplete> getByWriteIdAndKeywords(DomainId userId, List<String> keywords) {
+    public List<DiaryComplete> getByWriterIdAndKeywords(DomainId userId, List<String> keywords) {
         List<DiaryEntity> diaryEntities = diaryJpaRepository.findByWriterIdAndKeywords(userId.value(), keywords);
         return diaryEntities.stream()
                 .map(DiaryMapper::toCompleteDomain)

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/entity/DiaryEntity.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/entity/DiaryEntity.java
@@ -38,6 +38,9 @@ public class DiaryEntity extends BaseEntity {
     private List<ImageEntity> imageEntities = new ArrayList<>();
     @OneToMany(mappedBy = "diaryEntity", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<LikeEntity> likeEntities = new ArrayList<>();
+    @OneToMany(mappedBy = "diaryEntity", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<DiaryKeywordEntity> diaryKeywordEntities = new ArrayList<>();
+
 
     public DiaryEntity(UUID id, String content, String emotion, Boolean isPublic, LocalDate date, UUID writerId) {
         this.id = id;

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/entity/DiaryKeywordEntity.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/entity/DiaryKeywordEntity.java
@@ -25,11 +25,11 @@ public class DiaryKeywordEntity extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "keyword_id", insertable = false, updatable = false)
-    private KeywordEntity keyword;
+    private KeywordEntity keywordEntity;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "diary_id", insertable = false, updatable = false)
-    private DiaryEntity diary;
+    private DiaryEntity diaryEntity;
 
 
 }

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/entity/DiaryKeywordEntity.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/entity/DiaryKeywordEntity.java
@@ -1,0 +1,35 @@
+package com.canvas.persistence.jpa.diary.entity;
+
+import com.canvas.persistence.jpa.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "diary_keyword")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class DiaryKeywordEntity extends BaseEntity {
+
+    @Id
+    private UUID id;
+
+    @Column(name = "diary_id", nullable = false)
+    private UUID diaryId;
+
+    @Column(name = "keyword_id", nullable = false)
+    private UUID keywordId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "keyword_id", insertable = false, updatable = false)
+    private KeywordEntity keyword;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "diary_id", insertable = false, updatable = false)
+    private DiaryEntity diary;
+
+
+}

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/entity/KeywordEntity.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/entity/KeywordEntity.java
@@ -1,0 +1,26 @@
+package com.canvas.persistence.jpa.diary.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "keyword")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class KeywordEntity {
+
+    @Id
+    private UUID id;
+
+    private String name;
+
+    @OneToMany(mappedBy = "keywordEntity", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<DiaryKeywordEntity> diaryKeywordEntities = new ArrayList<>();
+
+}

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/repository/DiaryJpaRepository.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/repository/DiaryJpaRepository.java
@@ -62,9 +62,9 @@ public interface DiaryJpaRepository extends JpaRepository<DiaryEntity, UUID> {
         select d
         from DiaryEntity d
         where d.writerId = :writerId and d.id in (
-            select dk.diary.id
+            select dk.diaryEntity.id
             from DiaryKeywordEntity dk
-            join dk.keyword k
+            join dk.keywordEntity k
             where k.name in :keywords
         )
     """)

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/repository/DiaryJpaRepository.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/repository/DiaryJpaRepository.java
@@ -57,4 +57,16 @@ public interface DiaryJpaRepository extends JpaRepository<DiaryEntity, UUID> {
     Slice<DiaryEntity> findByUserLiked(Pageable pageable, UUID userId);
 
     boolean existsByIdAndWriterId(UUID diaryId, UUID writerId);
+
+    @Query("""
+        select d
+        from DiaryEntity d
+        where d.writerId = :writerId and d.id in (
+            select dk.diary.id
+            from DiaryKeywordEntity dk
+            join dk.keyword k
+            where k.name in :keywords
+        )
+    """)
+    List<DiaryEntity> findByWriterIdAndKeywords(UUID writerId, List<String> keywords);
 }


### PR DESCRIPTION
# 이슈
- #106 

# 구현 내용
- [x] 회고 api 및 dto 추가 
- [x] KeywordEntity와 DiaryKeywordEntity 추가
- [x] 회고 controller와 service, repository 연결
- [x] 과거 회고를 가져오는 쿼리 추가
- [ ] 감정 추출 로직 수정 필요
- [ ] 회상으로 보여줄 과거 일기 선택 로직 구현

# 세부 내용
- 일기와 키워드를 다대다로 설정
- 회고 api, dto 설계
- 회고 쿼리 추가
- port, usecase 생성 및 연결

# 고민한 내용
## 로직 흐름
![스크린샷 2024-11-13 오전 2 53 30](https://github.com/user-attachments/assets/8fb159e4-4bf6-4a2d-824c-02e0e8be75a3)
- 회고 구현을 위해 내가 생각한 흐름을 그려보았다.
- 일기 내용으로 키워드를 추출하고 키워드를 바로 저장하려 하였지만 diaryId가 존재하지 않아 저장이 어려워서 api를 분리하였다. 처음에는 세션을 이용해서 키워드를 세션에 저장해놓고 사용할까 고민하였다. 하지만 세션을 사용하면 Restful 원칙에 위배되기도 하고, 서버가 키워드를 가지고 있다가 검증을 굳이 하지 않아도 될 것 같다는 의견이 있었다. 
![스크린샷 2024-11-13 오전 3 53 47](https://github.com/user-attachments/assets/24a0e511-45ce-48e2-a061-c860a08b69a2)
그래서 그림을 수정하였다.
- 클라이언트가 키워드를 가지고 있다가 키워드 저장 api를 호출할 때 키워드를 같이 보내도록 변경하여 세션을 사용하지 않기로 하였다.

## 과거 일기 선택
- 과거 일기 선택 기준을 어떻게 잡아야 할 지 고민이다. 일기를 선택하는 기준은 매번 바뀔 수 있을 것 같아서 일단 추출한 키워드를 가지는 일기를 전부 가져오도록 하엿다. 가져온 일기를 `findDiaryForReminiscence` 함수로 구현할 예정이다.

## Gemini Prompt 및 반환값
현재는 
`일기에서 가장 핵심적인 키워드를 1~5개를 뽑아줘. 정확히 이 형식에 맞춰 뽑아줘. "keyword1, keyword2, keyword3, keyword4, keyword5"`
이렇게 설정하였지만 추가적인 프롬프트 엔지니어링이 필요할 것 같다.

