### PR TITLE
feat: 회고 일기 조회 기능 구현, gpt api 추가

### DIFF
--- a/Application-Module/build.gradle
+++ b/Application-Module/build.gradle
@@ -1,6 +1,11 @@
 dependencies {
     implementation(project(":Domain-Module"))
+    testImplementation(testFixtures(project(":Domain-Module")))
+    testFixturesImplementation(testFixtures(project(":Domain-Module")))
+
     implementation(project(":Common-Module"))
+    testImplementation(testFixtures(project(":Common-Module")))
+    testFixturesImplementation(testFixtures(project(":Common-Module")))
 
     implementation "org.springframework:spring-tx"
 }

--- a/Application-Module/src/main/java/com/canvas/application/diary/port/in/GetExploreDiaryUseCase.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/port/in/GetExploreDiaryUseCase.java
@@ -7,6 +7,7 @@ public interface GetExploreDiaryUseCase {
     Response getExploreByLike(Query query);
 
     record Query(
+            String userId,
             Integer page,
             Integer size
     ) {}
@@ -19,7 +20,8 @@ public interface GetExploreDiaryUseCase {
     ) {
         public record DiaryInfo(
                 String diaryId,
-                String mainImageUrl
+                String mainImageUrl,
+                Boolean isLiked
         ) {}
     }
 }

--- a/Application-Module/src/main/java/com/canvas/application/diary/port/in/GetReminiscenceDiaryUseCase.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/port/in/GetReminiscenceDiaryUseCase.java
@@ -1,0 +1,39 @@
+package com.canvas.application.diary.port.in;
+
+import com.canvas.domain.diary.enums.Emotion;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface GetReminiscenceDiaryUseCase {
+    Response getReminiscenceDiary(Query query);
+
+    record Query (
+            String userId,
+            String content,
+            LocalDate date
+    ){
+
+    }
+
+    record Response (
+        String diaryId,
+        String content,
+        Emotion emotion,
+        Integer likedCount,
+        Boolean isLiked,
+        LocalDate date,
+        List<ImageInfo> images,
+        List<String> keywords
+        ) {
+
+        public record ImageInfo(
+                String imageId,
+                Boolean isMain,
+                String imageUrl
+        ) {}
+    }
+
+
+
+}

--- a/Application-Module/src/main/java/com/canvas/application/diary/port/in/ModifyDiaryUseCase.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/port/in/ModifyDiaryUseCase.java
@@ -1,7 +1,5 @@
 package com.canvas.application.diary.port.in;
 
-import com.canvas.application.common.enums.Style;
-
 public interface ModifyDiaryUseCase {
     void modify(Command command);
 
@@ -9,7 +7,6 @@ public interface ModifyDiaryUseCase {
             String userId,
             String diaryId,
             String content,
-            Style style,
             Boolean isPublic
     ) {
     }

--- a/Application-Module/src/main/java/com/canvas/application/diary/port/out/DiaryKeywordExtractPort.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/port/out/DiaryKeywordExtractPort.java
@@ -1,0 +1,7 @@
+package com.canvas.application.diary.port.out;
+
+import java.util.List;
+
+public interface DiaryKeywordExtractPort {
+    List<String> keywordExtract(String content);
+}

--- a/Application-Module/src/main/java/com/canvas/application/diary/port/out/DiaryManagementPort.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/port/out/DiaryManagementPort.java
@@ -25,5 +25,6 @@ public interface DiaryManagementPort {
     Slice<DiaryComplete> getExploreByLatest(PageRequest pageRequest);
     Slice<DiaryComplete> getExploreByLike(PageRequest pageRequest);
     Slice<DiaryOverview> getLikedDiaries(PageRequest pageRequest, DomainId userId);
+    List<DiaryComplete> getByWriteIdAndKeywords(DomainId userId, List<String> keywords);
     void deleteById(DomainId diaryId);
 }

--- a/Application-Module/src/main/java/com/canvas/application/diary/port/out/DiaryManagementPort.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/port/out/DiaryManagementPort.java
@@ -22,8 +22,8 @@ public interface DiaryManagementPort {
     Slice<DiaryOverview> getAlbumByContent(PageRequest pageRequest, DomainId userId, String content);
     Slice<DiaryOverview> getAlbumByEmotion(PageRequest pageRequest, DomainId userId, Emotion emotion);
     Slice<DiaryOverview> getAlbumByContentAndEmotion(PageRequest pageRequest, DomainId userId, String content, Emotion emotion);
-    Slice<DiaryOverview> getExploreByLatest(PageRequest pageRequest);
-    Slice<DiaryOverview> getExploreByLike(PageRequest pageRequest);
+    Slice<DiaryComplete> getExploreByLatest(PageRequest pageRequest);
+    Slice<DiaryComplete> getExploreByLike(PageRequest pageRequest);
     Slice<DiaryOverview> getLikedDiaries(PageRequest pageRequest, DomainId userId);
     void deleteById(DomainId diaryId);
 }

--- a/Application-Module/src/main/java/com/canvas/application/diary/port/out/DiaryManagementPort.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/port/out/DiaryManagementPort.java
@@ -25,6 +25,6 @@ public interface DiaryManagementPort {
     Slice<DiaryComplete> getExploreByLatest(PageRequest pageRequest);
     Slice<DiaryComplete> getExploreByLike(PageRequest pageRequest);
     Slice<DiaryOverview> getLikedDiaries(PageRequest pageRequest, DomainId userId);
-    List<DiaryComplete> getByWriteIdAndKeywords(DomainId userId, List<String> keywords);
+    List<DiaryComplete> getByWriterIdAndKeywords(DomainId userId, List<String> keywords);
     void deleteById(DomainId diaryId);
 }

--- a/Application-Module/src/main/java/com/canvas/application/diary/port/out/DiaryManagementPort.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/port/out/DiaryManagementPort.java
@@ -10,6 +10,7 @@ import com.canvas.domain.diary.enums.Emotion;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 public interface DiaryManagementPort {
     DiaryComplete save(DiaryComplete diary);
@@ -25,6 +26,7 @@ public interface DiaryManagementPort {
     Slice<DiaryComplete> getExploreByLatest(PageRequest pageRequest);
     Slice<DiaryComplete> getExploreByLike(PageRequest pageRequest);
     Slice<DiaryOverview> getLikedDiaries(PageRequest pageRequest, DomainId userId);
-    List<DiaryComplete> getByWriterIdAndKeywords(DomainId userId, List<String> keywords);
+    List<DiaryComplete> getByWriterIdAndKeywords(DomainId userId, List<String> keywords, LocalDate baseDate);
+    Optional<DiaryComplete> getByWriterIdAndDate(DomainId userId, LocalDate beforeYear, LocalDate beforeMonth);
     void deleteById(DomainId diaryId);
 }

--- a/Application-Module/src/main/java/com/canvas/application/diary/service/DiaryCommandService.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/service/DiaryCommandService.java
@@ -53,17 +53,16 @@ public class DiaryCommandService
 
     @Override
     public void modify(ModifyDiaryUseCase.Command command) {
-        DomainId diarId = DomainId.from(command.diaryId());
-
         DiaryComplete diary = diaryManagementPort.getByIdAndWriterId(
-                diarId,
+                DomainId.from(command.diaryId()),
                 DomainId.from(command.userId())
         );
 
-        Emotion emotion = diaryEmotionExtractPort.emotionExtract(command.content());
-        Image image = createImage(diarId, command.content(), command.style());
+        if (!command.content().equals(diary.getContent())) {
+            Emotion emotion = diaryEmotionExtractPort.emotionExtract(command.content());
+            diary.updateDiaryContent(command.content(), emotion);
+        }
 
-        diary.updateDiaryContent(command.content(), emotion, image);
         diary.updatePublic(command.isPublic());
 
         diaryManagementPort.save(diary);

--- a/Application-Module/src/main/java/com/canvas/application/diary/service/DiaryCommandService.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/service/DiaryCommandService.java
@@ -70,7 +70,7 @@ public class DiaryCommandService
     }
 
     private Image createImage(DomainId diaryId, String content, Style style) {
-        String imageUrl = addImageUseCase.create(new AddImageUseCase.Command(diaryId.toString(), content, style)).imageUrl();
+        String imageUrl = addImageUseCase.create(new AddImageUseCase.Command.Create(diaryId.toString(), content, style)).imageUrl();
         return Image.create(DomainId.generate(), diaryId, true, imageUrl);
     }
 

--- a/Application-Module/src/main/java/com/canvas/application/diary/service/DiaryQueryService.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/service/DiaryQueryService.java
@@ -151,26 +151,27 @@ public class DiaryQueryService
 
     @Override
     public GetExploreDiaryUseCase.Response getExploreByLatest(GetExploreDiaryUseCase.Query query) {
-        Slice<DiaryOverview> slice = diaryManagementPort.getExploreByLatest(
+        Slice<DiaryComplete> slice = diaryManagementPort.getExploreByLatest(
                 new PageRequest(query.page(), query.size(), Sort.by(Sort.Direction.DESC, "createdAt")));
 
-        return toExploreResponse(slice);
+        return toExploreResponse(DomainId.from(query.userId()), slice);
     }
 
     @Override
     public GetExploreDiaryUseCase.Response getExploreByLike(GetExploreDiaryUseCase.Query query) {
-        Slice<DiaryOverview> slice = diaryManagementPort.getExploreByLike(
+        Slice<DiaryComplete> slice = diaryManagementPort.getExploreByLike(
                 new PageRequest(query.page(), query.size(), Sort.by(Sort.Direction.DESC, "createdAt")));
 
-        return toExploreResponse(slice);
+        return toExploreResponse(DomainId.from(query.userId()), slice);
     }
 
-    private static GetExploreDiaryUseCase.Response toExploreResponse(Slice<DiaryOverview> slice) {
+    private static GetExploreDiaryUseCase.Response toExploreResponse(DomainId userId, Slice<DiaryComplete> slice) {
         return new GetExploreDiaryUseCase.Response(
                 slice.content().stream()
                         .map(diary -> new GetExploreDiaryUseCase.Response.DiaryInfo(
                                 diary.getId().toString(),
-                                diary.getMainImageOrDefault()))
+                                diary.getMainImageOrDefault(),
+                                diary.isLiked(userId)))
                         .toList(),
                 slice.size(),
                 slice.number(),

--- a/Application-Module/src/main/java/com/canvas/application/diary/service/DiaryQueryService.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/service/DiaryQueryService.java
@@ -189,7 +189,7 @@ public class DiaryQueryService
 
         List<String> keywords = diaryKeywordExtractPort.keywordExtract(query.content());
 
-        List<DiaryComplete> diaries = diaryManagementPort.getByWriteIdAndKeywords(userId, keywords);
+        List<DiaryComplete> diaries = diaryManagementPort.getByWriterIdAndKeywords(userId, keywords);
 
         DiaryComplete reminiscenceDiary = findDiaryForReminiscence(diaries);
 

--- a/Application-Module/src/main/java/com/canvas/application/image/exception/ImageException.java
+++ b/Application-Module/src/main/java/com/canvas/application/image/exception/ImageException.java
@@ -1,4 +1,4 @@
-package com.canvas.application.image.port.exception;
+package com.canvas.application.image.exception;
 
 import com.canvas.common.exception.BusinessException;
 import org.springframework.http.HttpStatus;

--- a/Application-Module/src/main/java/com/canvas/application/image/port/in/AddImageUseCase.java
+++ b/Application-Module/src/main/java/com/canvas/application/image/port/in/AddImageUseCase.java
@@ -3,25 +3,33 @@ package com.canvas.application.image.port.in;
 import com.canvas.application.common.enums.Style;
 
 public interface AddImageUseCase {
-    Response.add add(Command command);
-    Response.create create(Command command);
+    Response.Add add(Command.Add command);
+    Response.Create create(Command.Create command);
 
-    record Command(
-            String diaryId,
-            String content,
-            Style style
-    ) {
+    class Command {
+        public record Add(
+                String diaryId,
+                Style style
+        ) {
+        }
+
+        public record Create(
+                String diaryId,
+                String content,
+                Style style
+        ) {
+        }
     }
 
     class Response {
-        public record add(
+        public record Add(
                 String imageId,
                 Boolean isMain,
                 String imageUrl
         ) {
         }
 
-        public record create(
+        public record Create(
                 String imageUrl
         ) {}
     }

--- a/Application-Module/src/main/java/com/canvas/application/image/service/ImageCommandService.java
+++ b/Application-Module/src/main/java/com/canvas/application/image/service/ImageCommandService.java
@@ -1,7 +1,7 @@
-package com.canvas.application.image.port.service;
+package com.canvas.application.image.service;
 
 import com.canvas.application.diary.port.out.DiaryManagementPort;
-import com.canvas.application.image.port.exception.ImageException;
+import com.canvas.application.image.exception.ImageException;
 import com.canvas.application.image.port.in.AddImageUseCase;
 import com.canvas.application.image.port.in.RemoveImageUseCase;
 import com.canvas.application.image.port.in.SetMainImageUseCase;

--- a/Application-Module/src/main/java/com/canvas/application/like/port/in/AddLikeUseCase.java
+++ b/Application-Module/src/main/java/com/canvas/application/like/port/in/AddLikeUseCase.java
@@ -1,4 +1,4 @@
-package com.canvas.application.like.in;
+package com.canvas.application.like.port.in;
 
 public interface AddLikeUseCase {
     void add(Command command);

--- a/Application-Module/src/main/java/com/canvas/application/like/port/in/CancelLikeUseCase.java
+++ b/Application-Module/src/main/java/com/canvas/application/like/port/in/CancelLikeUseCase.java
@@ -1,4 +1,4 @@
-package com.canvas.application.like.in;
+package com.canvas.application.like.port.in;
 
 public interface CancelLikeUseCase {
     void cancel(Command command);

--- a/Application-Module/src/main/java/com/canvas/application/like/port/out/LikeManagementPort.java
+++ b/Application-Module/src/main/java/com/canvas/application/like/port/out/LikeManagementPort.java
@@ -1,4 +1,4 @@
-package com.canvas.application.like.out;
+package com.canvas.application.like.port.out;
 
 import com.canvas.domain.common.DomainId;
 import com.canvas.domain.diary.entity.Like;

--- a/Application-Module/src/main/java/com/canvas/application/like/service/LikeCommandService.java
+++ b/Application-Module/src/main/java/com/canvas/application/like/service/LikeCommandService.java
@@ -1,8 +1,8 @@
 package com.canvas.application.like.service;
 
-import com.canvas.application.like.in.AddLikeUseCase;
-import com.canvas.application.like.in.CancelLikeUseCase;
-import com.canvas.application.like.out.LikeManagementPort;
+import com.canvas.application.like.port.in.AddLikeUseCase;
+import com.canvas.application.like.port.in.CancelLikeUseCase;
+import com.canvas.application.like.port.out.LikeManagementPort;
 import com.canvas.domain.common.DomainId;
 import com.canvas.domain.diary.entity.Like;
 import lombok.RequiredArgsConstructor;

--- a/Application-Module/src/main/java/com/canvas/application/user/service/UserTokenService.java
+++ b/Application-Module/src/main/java/com/canvas/application/user/service/UserTokenService.java
@@ -35,12 +35,12 @@ public class UserTokenService implements LoginUserUseCase, ReissueTokenUseCase, 
 
         User user = getUserOrRegister(userInfo, command.provider());
 
-        String userId = user.getDomainId().toString();
+        String userId = user.getId().toString();
 
         String accessToken = userTokenConvertPort.createAccessToken(userId);
         String refreshToken = userTokenConvertPort.createRefreshToken(userId);
 
-        userTokenManagementPort.save(new UserToken(DomainId.generate(), refreshToken, DomainId.from(userId)));
+//        userTokenManagementPort.save(UserToken.create(DomainId.generate(), refreshToken, DomainId.from(userId)));
 
         return new LoginUserUseCase.Response(accessToken, refreshToken);
     }
@@ -65,7 +65,7 @@ public class UserTokenService implements LoginUserUseCase, ReissueTokenUseCase, 
         if(userManagementPort.existsBySocialIdAndProviderId(userInfo.socialId(), SocialLoginProvider.parse(provider))) {
             return userManagementPort.getBySocialIdAndProvider(userInfo.socialId(), SocialLoginProvider.parse(provider));
         } else {
-            return userManagementPort.save(new User(DomainId.generate(), userInfo.username(),
+            return userManagementPort.save(User.create(DomainId.generate(), userInfo.username(),
                     userInfo.socialId(), SocialLoginProvider.parse(provider)));
         }
     }

--- a/Application-Module/src/test/java/com/canvas/application/diary/service/DiaryCommandServiceTest.java
+++ b/Application-Module/src/test/java/com/canvas/application/diary/service/DiaryCommandServiceTest.java
@@ -1,0 +1,181 @@
+package com.canvas.application.diary.service;
+
+import com.canvas.application.diary.exception.DiaryException;
+import com.canvas.application.diary.port.in.AddDiaryUseCase;
+import com.canvas.application.diary.port.in.ModifyDiaryUseCase;
+import com.canvas.application.diary.port.in.RemoveDiaryUseCase;
+import com.canvas.application.diary.port.out.DiaryEmotionExtractPort;
+import com.canvas.application.diary.port.out.DiaryManagementPort;
+import com.canvas.application.image.port.in.AddImageUseCase;
+import com.canvas.domain.common.DomainId;
+import com.canvas.domain.diary.entity.DiaryComplete;
+import com.canvas.domain.diary.entity.Image;
+import com.canvas.domain.diary.enums.Emotion;
+import com.canvas.domain.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static com.canvas.application.diary.DiaryApplicationFixture.*;
+import static com.canvas.domain.fixture.DiaryFixture.PUBLIC_MY_DIARY;
+import static com.canvas.domain.fixture.UserFixture.MYSELF;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class DiaryCommandServiceTest {
+
+    @Mock
+    private DiaryManagementPort diaryManagementPort;
+    @Mock
+    private DiaryEmotionExtractPort diaryEmotionExtractPort;
+    @Mock
+    private AddImageUseCase addImageUseCase;
+
+    @InjectMocks
+    private DiaryCommandService diaryCommandService;
+
+    @Test
+    @DisplayName("일기 생성 성공")
+    void addSuccessTest() {
+        // given
+        User user = MYSELF.getUser();
+        DiaryComplete diary = PUBLIC_MY_DIARY.getDiaryComplete();
+        AddDiaryUseCase.Command command = getAddDiaryCommand(user, diary);
+        String generatedImageUrl = "imageUrl";
+
+        given(diaryManagementPort.existsByWriterIdAndDate(user.getId(), diary.getDate()))
+                .willReturn(false);
+        given(diaryEmotionExtractPort.emotionExtract(command.content()))
+                .willReturn(diary.getEmotion());
+        given(addImageUseCase.create(any(AddImageUseCase.Command.Create.class)))
+                .willReturn(new AddImageUseCase.Response.Create(generatedImageUrl));
+
+        // when
+        AddDiaryUseCase.Response response = diaryCommandService.add(command);
+
+        // then
+        ArgumentCaptor<DiaryComplete> captor = ArgumentCaptor.forClass(DiaryComplete.class);
+        verify(diaryManagementPort).save(captor.capture());
+
+        DiaryComplete savedDiary = captor.getValue();
+        assertThat(savedDiary.getId()).isEqualTo(DomainId.from(response.diaryId()));
+        assertThat(savedDiary.getWriterId()).isEqualTo(diary.getWriterId());
+        assertThat(savedDiary.getContent()).isEqualTo(diary.getContent());
+        assertThat(savedDiary.getEmotion()).isEqualTo(diary.getEmotion());
+        assertThat(savedDiary.getDate()).isEqualTo(diary.getDate());
+        assertThat(savedDiary.getIsPublic()).isEqualTo(diary.getIsPublic());
+        assertThat(savedDiary.getImages())
+                .hasSize(1)
+                .extracting(Image::getImageUrl)
+                .containsExactly(generatedImageUrl);
+    }
+
+    @Test
+    @DisplayName("일기 생성 실패")
+    void addFailureTest() {
+        // given
+        User user = MYSELF.getUser();
+        DiaryComplete diary = PUBLIC_MY_DIARY.getDiaryComplete();
+        AddDiaryUseCase.Command command = getAddDiaryCommand(user, diary);
+
+        given(diaryManagementPort.existsByWriterIdAndDate(user.getId(), diary.getDate()))
+                .willReturn(true);
+
+        // when
+        // then
+        assertThatThrownBy(() -> diaryCommandService.add(command))
+                .isInstanceOf(DiaryException.DiaryBadRequestException.class);
+    }
+
+    @Test
+    @DisplayName("일기 공개 여부만 수정")
+    void modifyPublicTest() {
+        // given
+        User user = MYSELF.getUser();
+        DiaryComplete diary = PUBLIC_MY_DIARY.getDiaryComplete();
+        ModifyDiaryUseCase.Command command = getModifyDiaryCommand(user, diary, diary.getContent(), !diary.getIsPublic());
+
+        given(diaryManagementPort.getByIdAndWriterId(diary.getId(), diary.getWriterId()))
+                .willReturn(diary);
+
+        // when
+        diaryCommandService.modify(command);
+
+        // then
+        verify(diaryEmotionExtractPort, never()).emotionExtract(command.content());
+        verify(diaryManagementPort).save(diary);
+        assertThat(diary.getContent()).isEqualTo(command.content());
+        assertThat(diary.getIsPublic()).isEqualTo(command.isPublic());
+    }
+
+    @Test
+    @DisplayName("일기 내용, 공개 여부 모두 수정")
+    void modifyContentTest() {
+        // given
+        User user = MYSELF.getUser();
+        DiaryComplete diary = PUBLIC_MY_DIARY.getDiaryComplete();
+        String newContent = "새로운 내용";
+        Emotion newEmotion = Emotion.ANGER;
+        ModifyDiaryUseCase.Command command = getModifyDiaryCommand(user, diary, newContent, !diary.getIsPublic());
+
+        given(diaryManagementPort.getByIdAndWriterId(diary.getId(), diary.getWriterId()))
+                .willReturn(diary);
+        given(diaryEmotionExtractPort.emotionExtract(command.content()))
+                .willReturn(newEmotion);
+
+        // when
+        diaryCommandService.modify(command);
+
+        // then
+        verify(diaryEmotionExtractPort).emotionExtract(command.content());
+        verify(diaryManagementPort).save(diary);
+        assertThat(diary.getContent()).isEqualTo(command.content());
+        assertThat(diary.getIsPublic()).isEqualTo(command.isPublic());
+    }
+
+    @Test
+    @DisplayName("일기 삭제 성공")
+    void removeSuccessTest() {
+        // given
+        User user = MYSELF.getUser();
+        DiaryComplete diary = PUBLIC_MY_DIARY.getDiaryComplete();
+        RemoveDiaryUseCase.Command command = getRemoveDiaryCommand(user, diary);
+
+        given(diaryManagementPort.existsByIdAndWriterId(diary.getId(), user.getId()))
+                .willReturn(true);
+
+        // when
+        diaryCommandService.remove(command);
+
+        // then
+        verify(diaryManagementPort).deleteById(diary.getId());
+    }
+
+    @Test
+    @DisplayName("일기 삭제 실패")
+    void removeFailureTest() {
+        // given
+        User user = MYSELF.getUser();
+        DiaryComplete diary = PUBLIC_MY_DIARY.getDiaryComplete();
+        RemoveDiaryUseCase.Command command = getRemoveDiaryCommand(user, diary);
+
+        given(diaryManagementPort.existsByIdAndWriterId(diary.getId(), user.getId()))
+                .willReturn(false);
+
+        // when
+        // then
+        assertThatThrownBy(() -> diaryCommandService.remove(command))
+                .isInstanceOf(DiaryException.DiaryForbiddenException.class);
+        verify(diaryManagementPort, never()).deleteById(diary.getId());
+    }
+
+}

--- a/Application-Module/src/test/java/com/canvas/application/diary/service/DiaryQueryServiceTest.java
+++ b/Application-Module/src/test/java/com/canvas/application/diary/service/DiaryQueryServiceTest.java
@@ -1,0 +1,114 @@
+package com.canvas.application.diary.service;
+
+import com.canvas.application.diary.exception.DiaryException;
+import com.canvas.application.diary.port.in.GetDiaryUseCase;
+import com.canvas.application.diary.port.out.DiaryManagementPort;
+import com.canvas.domain.diary.entity.DiaryBasic;
+import com.canvas.domain.diary.entity.DiaryComplete;
+import com.canvas.domain.fixture.DiaryFixture;
+import com.canvas.domain.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static com.canvas.application.diary.DiaryApplicationFixture.getGetDiaryQuery;
+import static com.canvas.application.diary.DiaryApplicationFixture.getHomeCalendarQuery;
+import static com.canvas.domain.fixture.DiaryFixture.PRIVATE_OTHER_DIARY;
+import static com.canvas.domain.fixture.DiaryFixture.PUBLIC_MY_DIARY;
+import static com.canvas.domain.fixture.UserFixture.MYSELF;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class DiaryQueryServiceTest {
+
+    @Mock
+    private DiaryManagementPort diaryManagementPort;
+
+    @InjectMocks
+    private DiaryQueryService diaryQueryService;
+
+    @Test
+    @DisplayName("일기 단일 조회 성공")
+    void getDiarySuccessTest() {
+        // given
+        User user = MYSELF.getUser();
+        DiaryComplete diary = PUBLIC_MY_DIARY.getDiaryComplete();
+        GetDiaryUseCase.Query.Diary query = getGetDiaryQuery(user, diary);
+
+        given(diaryManagementPort.getById(diary.getId())).willReturn(diary);
+
+        // when
+        GetDiaryUseCase.Response.DiaryInfo response = diaryQueryService.getDiary(query);
+
+        // then
+        assertThat(response.diaryId()).isEqualTo(diary.getId().toString());
+        assertThat(response.content()).isEqualTo(diary.getContent());
+        assertThat(response.emotion()).isEqualTo(diary.getEmotion());
+        assertThat(response.likeCount()).isEqualTo(diary.getLikeCount());
+        assertThat(response.isLiked()).isEqualTo(diary.isLiked(user.getId()));
+        assertThat(response.isMine()).isEqualTo(diary.isWriter(user.getId()));
+        assertThat(response.date()).isEqualTo(diary.getDate());
+        assertThat(response.isPublic()).isEqualTo(diary.getIsPublic());
+        assertThat(response.images()).containsExactlyInAnyOrderElementsOf(diary.getImages().stream()
+                .map(image -> new GetDiaryUseCase.Response.DiaryInfo.ImageInfo(
+                        image.getId().toString(),
+                        image.getIsMain(),
+                        image.getImageUrl()
+                )).toList());
+
+    }
+
+    @Test
+    @DisplayName("일기 단일 조회 실패")
+    void getDiaryFailureTest() {
+        // given
+        User user = MYSELF.getUser();
+        DiaryComplete diary = PRIVATE_OTHER_DIARY.getDiaryComplete();
+        GetDiaryUseCase.Query.Diary query = getGetDiaryQuery(user, diary);
+
+        given(diaryManagementPort.getById(diary.getId())).willReturn(diary);
+
+        // when
+        // then
+        assertThatThrownBy(() -> diaryQueryService.getDiary(query))
+                .isInstanceOf(DiaryException.DiaryForbiddenException.class);
+    }
+
+    @Test
+    @DisplayName("홈 달력 조회")
+    void getHomeCalendarTest() {
+        // given
+        User user = MYSELF.getUser();
+        LocalDate date = LocalDate.now();
+        GetDiaryUseCase.Query.HomeCalendar query = getHomeCalendarQuery(user, date);
+        List<DiaryBasic> diaries = DiaryFixture.getAllDiaryBasicByUser(MYSELF);
+
+        given(diaryManagementPort.getByUserIdAndMonth(user.getId(), date))
+                .willReturn(diaries);
+
+        // when
+        GetDiaryUseCase.Response.HomeCalendar response = diaryQueryService.getHomeCalendar(query);
+
+        // then
+        assertThat(response.diaries())
+                .hasSameSizeAs(diaries)
+                .allSatisfy(diaryInfo -> {
+                    DiaryBasic matchingDiary = diaries.stream()
+                                                      .filter(diary -> diary.getId().toString().equals(diaryInfo.diaryId()))
+                                                      .findFirst()
+                                                      .orElseThrow();
+
+                    assertThat(diaryInfo.date()).isEqualTo(matchingDiary.getDate());
+                    assertThat(diaryInfo.emotion()).isEqualTo(matchingDiary.getEmotion());
+                });
+    }
+
+}

--- a/Application-Module/src/test/java/com/canvas/application/image/service/ImageCommandServiceTest.java
+++ b/Application-Module/src/test/java/com/canvas/application/image/service/ImageCommandServiceTest.java
@@ -1,0 +1,174 @@
+package com.canvas.application.image.service;
+
+import com.canvas.application.diary.port.out.DiaryManagementPort;
+import com.canvas.application.image.exception.ImageException;
+import com.canvas.application.image.port.in.AddImageUseCase;
+import com.canvas.application.image.port.in.RemoveImageUseCase;
+import com.canvas.application.image.port.in.SetMainImageUseCase;
+import com.canvas.application.image.port.out.ImageGenerationPort;
+import com.canvas.application.image.port.out.ImageManagementPort;
+import com.canvas.application.image.port.out.ImagePromptGeneratePort;
+import com.canvas.application.image.port.out.ImageUploadPort;
+import com.canvas.domain.diary.entity.DiaryComplete;
+import com.canvas.domain.diary.entity.DiaryOverview;
+import com.canvas.domain.diary.entity.Image;
+import com.canvas.domain.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static com.canvas.application.image.ImageApplicationFixture.*;
+import static com.canvas.domain.fixture.DiaryFixture.PUBLIC_MY_DIARY;
+import static com.canvas.domain.fixture.ImageFixture.PUBLIC_MY_DIARY_IMAGE2;
+import static com.canvas.domain.fixture.UserFixture.MYSELF;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ImageCommandServiceTest {
+
+    @Mock
+    private DiaryManagementPort diaryManagementPort;
+    @Mock
+    private ImageGenerationPort imageGenerationPort;
+    @Mock
+    private ImageManagementPort imageManagementPort;
+    @Mock
+    private ImagePromptGeneratePort imagePromptGeneratePort;
+    @Mock
+    private ImageUploadPort imageUploadPort;
+
+    @Spy
+    @InjectMocks
+    private ImageCommandService imageCommandService;
+
+    @Test
+    @DisplayName("이미지 추가")
+    void addTest() {
+        // given
+        DiaryComplete diary = PUBLIC_MY_DIARY.getDiaryComplete();
+        Image image = PUBLIC_MY_DIARY_IMAGE2.getImage();
+
+        AddImageUseCase.Command.Add command = getAddImageCommand(diary);
+
+        given(diaryManagementPort.getById(diary.getId())).willReturn(diary);
+        doReturn(new AddImageUseCase.Response.Create(image.getImageUrl())).when(imageCommandService).create(any());
+
+        // when
+        AddImageUseCase.Response.Add response = imageCommandService.add(command);
+
+        // then
+        verify(imageCommandService).create(any(AddImageUseCase.Command.Create.class));
+        verify(imageManagementPort).save(any(Image.class));
+        assertThat(response.isMain()).isFalse();
+        assertThat(response.imageUrl()).isEqualTo(image.getImageUrl());
+    }
+
+    @Test
+    @DisplayName("이미지 생성")
+    void createTest() {
+        // given
+        AddImageUseCase.Command.Create command = getCreateImageCommand();
+
+        given(imagePromptGeneratePort.generatePrompt(command.content())).willReturn("prompt");
+        given(imageGenerationPort.generate("prompt", command.style())).willReturn("generatedImageUrl");
+        given(imageUploadPort.upload("generatedImageUrl")).willReturn("uploadedImageUrl");
+
+        // when
+        AddImageUseCase.Response.Create response = imageCommandService.create(command);
+
+        // then
+        assertThat(response.imageUrl()).isEqualTo("uploadedImageUrl");
+    }
+
+    @Test
+    @DisplayName("이미지 삭제 성공")
+    void removeSuccessTest() {
+        // given
+        User user = MYSELF.getUser();
+        Image image = PUBLIC_MY_DIARY_IMAGE2.getImage();
+        RemoveImageUseCase.Command command = getRemoveImageCommand(user, image);
+
+        given(imageManagementPort.existsByIdAndUserId(image.getId(), user.getId())).willReturn(true);
+
+        // when
+        imageCommandService.remove(command);
+
+        // then
+        verify(imageManagementPort).deleteById(image.getId());
+    }
+
+    @Test
+    @DisplayName("이미지 삭제 실패")
+    void removeFailureTest() {
+        // given
+        User user = MYSELF.getUser();
+        Image image = PUBLIC_MY_DIARY_IMAGE2.getImage();
+        RemoveImageUseCase.Command command = getRemoveImageCommand(user, image);
+
+        given(imageManagementPort.existsByIdAndUserId(image.getId(), user.getId())).willReturn(false);
+
+        // when
+        // then
+        assertThatThrownBy(() -> imageCommandService.remove(command))
+                .isInstanceOf(ImageException.ImageNotFoundException.class);
+        verify(imageManagementPort, never()).deleteById(image.getId());
+    }
+
+    @Test
+    @DisplayName("메인 이미지 변경 성공")
+    void setMainImageSuccessTest() {
+        // given
+        DiaryOverview diary = PUBLIC_MY_DIARY.getDiaryOverview();
+        Image image = PUBLIC_MY_DIARY_IMAGE2.getImage();
+        User user = MYSELF.getUser();
+        SetMainImageUseCase.Command command = getSetMainImageCommand(user, image);
+
+        given(imageManagementPort.getAllInDiaryByIdAndWriterId(image.getId(), diary.getWriterId()))
+                .willReturn(diary.getImages());
+
+        // when
+        imageCommandService.setMain(command);
+
+        // then
+        verify(imageManagementPort).saveAll(diary.getImages());
+        assertThat(diary.getImages())
+                .anySatisfy(img -> {
+                    assertThat(img.getId()).isEqualTo(image.getId());
+                    assertThat(img.isMain()).isTrue();
+                })
+                .allSatisfy(img -> {
+                    if (!img.getId().equals(image.getId())) {
+                        assertThat(img.isMain()).isFalse();
+                    }
+                });
+    }
+
+    @Test
+    @DisplayName("메인 이미지 변경 실패")
+    void setMainFailureTest() {
+        // given
+        DiaryOverview diary = PUBLIC_MY_DIARY.getDiaryOverview();
+        Image image = PUBLIC_MY_DIARY_IMAGE2.getImage();
+        User user = MYSELF.getUser();
+        SetMainImageUseCase.Command command = getSetMainImageCommand(user, image);
+
+        given(imageManagementPort.getAllInDiaryByIdAndWriterId(image.getId(), diary.getWriterId()))
+                .willReturn(List.of());
+
+        // when
+        // then
+        assertThatThrownBy(() -> imageCommandService.setMain(command))
+                .isInstanceOf(ImageException.ImageNotFoundException.class);
+    }
+
+}

--- a/Application-Module/src/test/java/com/canvas/application/like/service/LikeCommandServiceTest.java
+++ b/Application-Module/src/test/java/com/canvas/application/like/service/LikeCommandServiceTest.java
@@ -1,0 +1,62 @@
+package com.canvas.application.like.service;
+
+import com.canvas.application.like.port.in.AddLikeUseCase;
+import com.canvas.application.like.port.in.CancelLikeUseCase;
+import com.canvas.application.like.port.out.LikeManagementPort;
+import com.canvas.domain.diary.entity.DiaryComplete;
+import com.canvas.domain.diary.entity.Like;
+import com.canvas.domain.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static com.canvas.application.like.LikeApplicationFixture.getAddLikeCommand;
+import static com.canvas.application.like.LikeApplicationFixture.getCancelLikeCommand;
+import static com.canvas.domain.fixture.DiaryFixture.PUBLIC_OTHER_DIARY;
+import static com.canvas.domain.fixture.UserFixture.MYSELF;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class LikeCommandServiceTest {
+
+    @Mock
+    private LikeManagementPort likeManagementPort;
+
+    @InjectMocks
+    private LikeCommandService likeCommandService;
+
+    @Test
+    @DisplayName("좋아요 추가")
+    void addTest() {
+        // given
+        User user = MYSELF.getUser();
+        DiaryComplete diary = PUBLIC_OTHER_DIARY.getDiaryComplete();
+        AddLikeUseCase.Command command = getAddLikeCommand(user, diary);
+
+        // when
+        likeCommandService.add(command);
+
+        // then
+        verify(likeManagementPort).add(any(Like.class));
+    }
+
+    @Test
+    @DisplayName("좋아요 취소")
+    void cancelTest() {
+        // given
+        User user = MYSELF.getUser();
+        DiaryComplete diary = PUBLIC_OTHER_DIARY.getDiaryComplete();
+        CancelLikeUseCase.Command command = getCancelLikeCommand(user, diary);
+
+        // when
+        likeCommandService.cancel(command);
+
+        // then
+        verify(likeManagementPort).remove(user.getId(), diary.getId());
+    }
+
+}

--- a/Application-Module/src/testFixtures/java/com/canvas/application/diary/DiaryApplicationFixture.java
+++ b/Application-Module/src/testFixtures/java/com/canvas/application/diary/DiaryApplicationFixture.java
@@ -1,0 +1,103 @@
+package com.canvas.application.diary;
+
+import com.canvas.application.common.enums.Style;
+import com.canvas.application.diary.port.in.*;
+import com.canvas.domain.diary.entity.DiaryComplete;
+import com.canvas.domain.diary.enums.Emotion;
+import com.canvas.domain.user.entity.User;
+
+import java.time.LocalDate;
+
+public class DiaryApplicationFixture {
+    public static AddDiaryUseCase.Command getAddDiaryCommand(User user, DiaryComplete diary) {
+        return new AddDiaryUseCase.Command(
+                user.getId().toString(),
+                diary.getDate(),
+                diary.getContent(),
+                Style.PHOTOREALISTIC,
+                diary.getIsPublic()
+        );
+    }
+
+    public static ModifyDiaryUseCase.Command getModifyDiaryCommand(User user, DiaryComplete diary, String content, Boolean isPublic) {
+        return new ModifyDiaryUseCase.Command(
+                user.getId().toString(),
+                diary.getId().toString(),
+                content,
+                isPublic
+        );
+    }
+
+    public static RemoveDiaryUseCase.Command getRemoveDiaryCommand(User user, DiaryComplete diary) {
+        return new RemoveDiaryUseCase.Command(
+                diary.getId().toString(),
+                user.getId().toString()
+        );
+    }
+
+    public static GetDiaryUseCase.Query.Diary getGetDiaryQuery(User user, DiaryComplete diary) {
+        return new GetDiaryUseCase.Query.Diary(
+                user.getId().toString(),
+                diary.getId().toString()
+        );
+    }
+
+    public static GetDiaryUseCase.Query.HomeCalendar getHomeCalendarQuery(User user, LocalDate date) {
+        return new GetDiaryUseCase.Query.HomeCalendar(
+                user.getId().toString(),
+                date
+        );
+    }
+
+    public static GetDiaryUseCase.Query.LikedDiaries getLikedDiariesQuery(User user) {
+        return new GetDiaryUseCase.Query.LikedDiaries(
+                user.getId().toString(),
+                0,
+                9
+        );
+    }
+
+    public static GetAlbumDiaryUseCase.Query.Recent getAlbumDiariesQuery(User user) {
+        return new GetAlbumDiaryUseCase.Query.Recent(
+                user.getId().toString(),
+                0,
+                9
+        );
+    }
+
+    public static GetAlbumDiaryUseCase.Query.Content getAlbumDiariesByContentQuery(User user, String content) {
+        return new GetAlbumDiaryUseCase.Query.Content(
+                user.getId().toString(),
+                content,
+                0,
+                9
+        );
+    }
+
+    public static GetAlbumDiaryUseCase.Query.Emotion getAlbumDiariesByEmotionQuery(User user, Emotion emotion) {
+        return new GetAlbumDiaryUseCase.Query.Emotion(
+                user.getId().toString(),
+                emotion.name(),
+                0,
+                9
+        );
+    }
+
+    public static GetAlbumDiaryUseCase.Query.All getAlbumDiariesByContentAndEmotionQuery(User user, String content, Emotion emotion) {
+        return new GetAlbumDiaryUseCase.Query.All(
+                user.getId().toString(),
+                content,
+                emotion.name(),
+                0,
+                9
+        );
+    }
+
+    public static GetExploreDiaryUseCase.Query getExploreDiaryQuery(User user) {
+        return new GetExploreDiaryUseCase.Query(
+                user.getId().toString(),
+                0,
+                9
+        );
+    }
+}

--- a/Application-Module/src/testFixtures/java/com/canvas/application/image/ImageApplicationFixture.java
+++ b/Application-Module/src/testFixtures/java/com/canvas/application/image/ImageApplicationFixture.java
@@ -1,0 +1,42 @@
+package com.canvas.application.image;
+
+import com.canvas.application.common.enums.Style;
+import com.canvas.application.image.port.in.AddImageUseCase;
+import com.canvas.application.image.port.in.RemoveImageUseCase;
+import com.canvas.application.image.port.in.SetMainImageUseCase;
+import com.canvas.domain.common.DomainId;
+import com.canvas.domain.diary.entity.DiaryComplete;
+import com.canvas.domain.diary.entity.Image;
+import com.canvas.domain.user.entity.User;
+
+public class ImageApplicationFixture {
+    public static AddImageUseCase.Command.Add getAddImageCommand(DiaryComplete diary) {
+        return new AddImageUseCase.Command.Add(
+                diary.getId().toString(),
+                Style.PHOTOREALISTIC
+        );
+    }
+
+    public static AddImageUseCase.Command.Create getCreateImageCommand() {
+        return new AddImageUseCase.Command.Create(
+                DomainId.generate().toString(),
+                "content",
+                Style.PHOTOREALISTIC
+        );
+    }
+
+    public static RemoveImageUseCase.Command getRemoveImageCommand(User user, Image image) {
+        return new RemoveImageUseCase.Command(
+                user.getId().toString(),
+                image.getDiaryId().toString(),
+                image.getId().toString()
+        );
+    }
+
+    public static SetMainImageUseCase.Command getSetMainImageCommand(User user, Image image) {
+        return new SetMainImageUseCase.Command(
+                user.getId().toString(),
+                image.getId().toString()
+        );
+    }
+}

--- a/Application-Module/src/testFixtures/java/com/canvas/application/like/LikeApplicationFixture.java
+++ b/Application-Module/src/testFixtures/java/com/canvas/application/like/LikeApplicationFixture.java
@@ -1,0 +1,22 @@
+package com.canvas.application.like;
+
+import com.canvas.application.like.port.in.AddLikeUseCase;
+import com.canvas.application.like.port.in.CancelLikeUseCase;
+import com.canvas.domain.diary.entity.DiaryComplete;
+import com.canvas.domain.user.entity.User;
+
+public class LikeApplicationFixture {
+    public static AddLikeUseCase.Command getAddLikeCommand(User user, DiaryComplete diaryComplete) {
+        return new AddLikeUseCase.Command(
+                user.getId().toString(),
+                diaryComplete.getId().toString()
+        );
+    }
+
+    public static CancelLikeUseCase.Command getCancelLikeCommand(User user, DiaryComplete diaryComplete) {
+        return new CancelLikeUseCase.Command(
+                user.getId().toString(),
+                diaryComplete.getId().toString()
+        );
+    }
+}

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/common/filter/CorsFilter.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/common/filter/CorsFilter.java
@@ -36,7 +36,7 @@ public class CorsFilter extends OncePerRequestFilter {
         }
 
         response.addHeader("Access-Control-Allow-Origin", origin);
-        response.setHeader("Access-Control-Allow-Methods", "GET, POST, PATCH, DELETE, OPTIONS");
+        response.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS");
         response.setHeader("Access-Control-Allow-Headers", "*, Content-Type, Authorization");
         response.setHeader("Access-Control-Allow-Credentials", "true");
 

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/common/filter/CorsFilter.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/common/filter/CorsFilter.java
@@ -37,7 +37,7 @@ public class CorsFilter extends OncePerRequestFilter {
 
         response.addHeader("Access-Control-Allow-Origin", origin);
         response.setHeader("Access-Control-Allow-Methods", "GET, POST, PATCH, DELETE, OPTIONS");
-        response.setHeader("Access-Control-Allow-Headers", "*, Authorization");
+        response.setHeader("Access-Control-Allow-Headers", "*, Content-Type, Authorization");
         response.setHeader("Access-Control-Allow-Credentials", "true");
 
         response.setContentType("application/json");

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/api/DiaryApi.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/api/DiaryApi.java
@@ -51,7 +51,7 @@ public interface DiaryApi {
 
 
     @Operation(summary = "일기 내용 수정")
-    @PatchMapping("/{diaryId}")
+    @PutMapping("/{diaryId}")
     @ApiResponses(value = {
             @ApiResponse(
                     responseCode = "200",

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/api/DiaryApi.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/api/DiaryApi.java
@@ -130,7 +130,8 @@ public interface DiaryApi {
                     description = "쿼리 스트링 오류"
             )
     })
-    SliceResponse<DiaryThumbnail> exploreDiary(
+    SliceResponse<ExploreDiaryResponse> exploreDiary(
+            @AccessUser String userId,
             @RequestParam int page,
             @RequestParam int size,
             @RequestParam ExploreOrder order

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/api/DiaryApi.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/api/DiaryApi.java
@@ -164,4 +164,18 @@ public interface DiaryApi {
             @RequestParam Integer page,
             @RequestParam Integer size
     );
+
+    @Operation(summary = "회고 일기 조회")
+    @PostMapping("/reminiscence")
+    ReminiscenceResponse getReminiscenceDiary(
+            @AccessUser String userId, @RequestBody ReminiscenceRequest request
+    );
+
+    @Operation(summary = "키워드 저장")
+    @PostMapping("/{diaryId}/reminiscence")
+    void saveKeyword(
+            @AccessUser String userId,
+            @PathVariable String diaryId,
+            @RequestBody SaveKeywordRequest request
+    );
 }

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/controller/DiaryController.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/controller/DiaryController.java
@@ -20,6 +20,7 @@ public class DiaryController implements DiaryApi {
     private final GetExploreDiaryUseCase getExploreDiaryUseCase;
     private final ModifyDiaryUseCase modifyDiaryUseCase;
     private final RemoveDiaryUseCase removeDiaryUseCase;
+    private final GetReminiscenceDiaryUseCase getReminiscenceDiaryUseCase;
 
     @Override
     public CreateDiaryResponse createDiary(String userId, CreateDiaryRequest request) {
@@ -162,8 +163,25 @@ public class DiaryController implements DiaryApi {
 
     @Override
     public ReminiscenceResponse getReminiscenceDiary(String userId, ReminiscenceRequest request) {
+        GetReminiscenceDiaryUseCase.Response response = getReminiscenceDiaryUseCase.getReminiscenceDiary(
+                new GetReminiscenceDiaryUseCase.Query(
+                    userId,
+                    request.content(),
+                    request.date()
+        ));
 
-        return null;
+        return new ReminiscenceResponse(
+                response.diaryId(),
+                response.content(),
+                response.emotion(),
+                response.likedCount(),
+                response.isLiked(),
+                response.date(),
+                response.images().stream()
+                        .map(image -> new ReminiscenceResponse.ImageInfo(image.imageId(), image.isMain(), image.imageUrl()))
+                        .toList(),
+                response.keywords()
+        );
     }
 
     @Override

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/controller/DiaryController.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/controller/DiaryController.java
@@ -160,4 +160,15 @@ public class DiaryController implements DiaryApi {
         );
     }
 
+    @Override
+    public ReminiscenceResponse getReminiscenceDiary(String userId, ReminiscenceRequest request) {
+
+        return null;
+    }
+
+    @Override
+    public void saveKeyword(String userId, String diaryId, SaveKeywordRequest request) {
+
+    }
+
 }

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/controller/DiaryController.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/controller/DiaryController.java
@@ -121,15 +121,18 @@ public class DiaryController implements DiaryApi {
     }
 
     @Override
-    public SliceResponse<DiaryThumbnail> exploreDiary(int page, int size, ExploreOrder order) {
+    public SliceResponse<ExploreDiaryResponse> exploreDiary(String userId, int page, int size, ExploreOrder order) {
         GetExploreDiaryUseCase.Response response = switch (order) {
-            case LATEST -> getExploreDiaryUseCase.getExploreByLatest(new GetExploreDiaryUseCase.Query(page, size));
-            case POPULARITY -> getExploreDiaryUseCase.getExploreByLike(new GetExploreDiaryUseCase.Query(page, size));
+            case LATEST -> getExploreDiaryUseCase.getExploreByLatest(new GetExploreDiaryUseCase.Query(userId, page, size));
+            case POPULARITY -> getExploreDiaryUseCase.getExploreByLike(new GetExploreDiaryUseCase.Query(userId, page, size));
         };
 
         return new SliceResponse<>(
                 response.diaries().stream()
-                        .map(diaryInfo -> new DiaryThumbnail(diaryInfo.diaryId(), diaryInfo.mainImageUrl()))
+                        .map(diaryInfo -> new ExploreDiaryResponse(
+                                diaryInfo.diaryId(),
+                                diaryInfo.mainImageUrl(),
+                                diaryInfo.isLiked()))
                         .toList(),
                 response.size(),
                 response.number(),

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/controller/DiaryController.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/controller/DiaryController.java
@@ -74,7 +74,7 @@ public class DiaryController implements DiaryApi {
     @Override
     public void updateDiary(String userId, String diaryId, UpdateDiaryRequest request) {
         modifyDiaryUseCase.modify(new ModifyDiaryUseCase.Command(
-                userId, diaryId, request.content(), request.style(), request.isPublic()
+                userId, diaryId, request.content(), request.isPublic()
         ));
     }
 

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/ExploreDiaryResponse.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/ExploreDiaryResponse.java
@@ -1,0 +1,12 @@
+package com.canvas.bootstrap.diary.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ExploreDiaryResponse(
+        @Schema(description = "일기 ID")
+        String diaryId,
+        @Schema(description = "일기 메인 이미지 url")
+        String mainImageUrl,
+        @Schema(description = "좋아요 선택 여부")
+        Boolean isLiked
+) {}

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/ReminiscenceRequest.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/ReminiscenceRequest.java
@@ -1,0 +1,14 @@
+package com.canvas.bootstrap.diary.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+
+@Schema(description = "과거 일기 조히 요청")
+public record ReminiscenceRequest(
+        @Schema(description = "일기 내용")
+        String content,
+        @Schema(description = "일기 날짜")
+        LocalDate date
+) {
+}

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/ReminiscenceResponse.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/ReminiscenceResponse.java
@@ -21,7 +21,10 @@ public record ReminiscenceResponse(
         @Schema(description = "과거 일기 생성 날짜")
         LocalDate date,
         @Schema(description = "과거 일기의 이미지 정보 리스트")
-        List<ReminiscenceResponse.ImageInfo> images) {
+        List<ReminiscenceResponse.ImageInfo> images,
+        @Schema(description = "추출된 키워드 리스트")
+        List<String> keywords
+    ) {
     @Schema(description = "일기의 이미지 정보")
     public record ImageInfo(
             @Schema(description = "이미지 ID")

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/ReminiscenceResponse.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/ReminiscenceResponse.java
@@ -6,7 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import java.util.List;
 
-@Schema(description = "과거 일기 조히 응답")
+@Schema(description = "과거 일기 조회 응답")
 public record ReminiscenceResponse(
         @Schema(description = "과거 일기 ID")
         String diaryId,

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/ReminiscenceResponse.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/ReminiscenceResponse.java
@@ -1,0 +1,35 @@
+package com.canvas.bootstrap.diary.dto;
+
+import com.canvas.domain.diary.enums.Emotion;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Schema(description = "과거 일기 조히 응답")
+public record ReminiscenceResponse(
+        @Schema(description = "과거 일기 ID")
+        String diaryId,
+        @Schema(description = "과거 일기 내용")
+        String content,
+        @Schema(description = "과거 일기의 감정")
+        Emotion emotion,
+        @Schema(description = "과거 일기 좋아요 수")
+        Integer likedCount,
+        @Schema(description = "과거 일기 좋아요 선택 여부")
+        Boolean isLiked,
+        @Schema(description = "과거 일기 생성 날짜")
+        LocalDate date,
+        @Schema(description = "과거 일기의 이미지 정보 리스트")
+        List<ReminiscenceResponse.ImageInfo> images) {
+    @Schema(description = "일기의 이미지 정보")
+    public record ImageInfo(
+            @Schema(description = "이미지 ID")
+            String imageId,
+            @Schema(description = "대표 이미지 여부")
+            Boolean isMain,
+            @Schema(description = "저장된 일기 이미지 url")
+            String imageUrl
+    ) {
+    }
+}

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/SaveKeywordRequest.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/SaveKeywordRequest.java
@@ -2,14 +2,11 @@ package com.canvas.bootstrap.diary.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-import java.time.LocalDate;
 import java.util.List;
 
 @Schema(description = "키워드 저장 요청")
 public record SaveKeywordRequest(
         @Schema(description = "저장할 키워드 리스트")
-        List<String> keywords,
-        @Schema(description = "일기 날짜")
-        LocalDate date
+        List<String> keywords
 ) {
 }

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/SaveKeywordRequest.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/SaveKeywordRequest.java
@@ -1,0 +1,15 @@
+package com.canvas.bootstrap.diary.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Schema(description = "키워드 저장 요청")
+public record SaveKeywordRequest(
+        @Schema(description = "저장할 키워드 리스트")
+        List<String> keywords,
+        @Schema(description = "일기 날짜")
+        LocalDate date
+) {
+}

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/UpdateDiaryRequest.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/dto/UpdateDiaryRequest.java
@@ -1,15 +1,12 @@
 package com.canvas.bootstrap.diary.dto;
 
-import com.canvas.application.common.enums.Style;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "일기 수정 요청")
 public record UpdateDiaryRequest(
         @Schema(description = "일기 내용")
         String content,
-        @Schema(description = "일기 화풍")
-        Style style,
         @Schema(description = "일기 공개 여부")
-        boolean isPublic
+        Boolean isPublic
 ) {
 }

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/image/controllor/ImageController.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/image/controllor/ImageController.java
@@ -19,9 +19,7 @@ public class ImageController implements ImageApi {
     @Override
     public void createImage(String userId, String diaryId, CreateImageRequest createImageRequest) {
         addImageUseCase.add(
-                new AddImageUseCase.Command(
-                        diaryId, createImageRequest.content(), createImageRequest.style()
-                ));
+                new AddImageUseCase.Command.Add(diaryId, createImageRequest.style()));
     }
 
     @Override

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/image/dto/CreateImageRequest.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/image/dto/CreateImageRequest.java
@@ -5,8 +5,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "이미지 추가 요청")
 public record CreateImageRequest(
-        @Schema(description = "일기 내용")
-        String content,
         @Schema(description = "일기 화풍")
         Style style
 ) {

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/like/controller/LikeController.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/like/controller/LikeController.java
@@ -1,7 +1,7 @@
 package com.canvas.bootstrap.like.controller;
 
-import com.canvas.application.like.in.AddLikeUseCase;
-import com.canvas.application.like.in.CancelLikeUseCase;
+import com.canvas.application.like.port.in.AddLikeUseCase;
+import com.canvas.application.like.port.in.CancelLikeUseCase;
 import com.canvas.application.like.service.LikeCommandService;
 import com.canvas.bootstrap.like.api.LikeApi;
 import lombok.RequiredArgsConstructor;

--- a/Common-Module/src/testFixtures/java/com/canvas/command/page/PageRequestFixture.java
+++ b/Common-Module/src/testFixtures/java/com/canvas/command/page/PageRequestFixture.java
@@ -1,0 +1,10 @@
+package com.canvas.command.page;
+
+import com.canvas.common.page.PageRequest;
+import com.canvas.common.page.Sort;
+
+public class PageRequestFixture {
+    public static PageRequest getPageRequest() {
+        return new PageRequest(1, 9, Sort.by(Sort.Direction.DESC, "createdAt"));
+    }
+}

--- a/Domain-Module/src/main/java/com/canvas/domain/diary/entity/DiaryBasic.java
+++ b/Domain-Module/src/main/java/com/canvas/domain/diary/entity/DiaryBasic.java
@@ -2,13 +2,14 @@ package com.canvas.domain.diary.entity;
 
 import com.canvas.domain.common.DomainId;
 import com.canvas.domain.diary.enums.Emotion;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public class DiaryBasic {
     // 조회 전용 도메인

--- a/Domain-Module/src/main/java/com/canvas/domain/diary/entity/DiaryComplete.java
+++ b/Domain-Module/src/main/java/com/canvas/domain/diary/entity/DiaryComplete.java
@@ -78,10 +78,9 @@ public class DiaryComplete {
         this.likes.add(like);
     }
 
-    public void updateDiaryContent(String content, Emotion emotion, Image image) {
+    public void updateDiaryContent(String content, Emotion emotion) {
         this.content = content;
         this.emotion = emotion;
-        this.images = new ArrayList<>(List.of(image));
     }
 
     public void updatePublic(Boolean isPublic) {

--- a/Domain-Module/src/main/java/com/canvas/domain/diary/entity/DiaryComplete.java
+++ b/Domain-Module/src/main/java/com/canvas/domain/diary/entity/DiaryComplete.java
@@ -100,4 +100,12 @@ public class DiaryComplete {
         return writerId.value().equals(userId.value());
     }
 
+    public String getMainImageOrDefault() {
+        return images.stream()
+                     .filter(Image::isMain)
+                     .map(Image::getImageUrl)
+                     .findFirst()
+                     .orElse(Image.DEFAULT_IMAGE_URL);
+    }
+
 }

--- a/Domain-Module/src/main/java/com/canvas/domain/diary/entity/DiaryOverview.java
+++ b/Domain-Module/src/main/java/com/canvas/domain/diary/entity/DiaryOverview.java
@@ -2,6 +2,7 @@ package com.canvas.domain.diary.entity;
 
 import com.canvas.domain.common.DomainId;
 import com.canvas.domain.diary.enums.Emotion;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -9,7 +10,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public class DiaryOverview {
     // 조회 전용 도메인

--- a/Domain-Module/src/main/java/com/canvas/domain/diary/entity/Image.java
+++ b/Domain-Module/src/main/java/com/canvas/domain/diary/entity/Image.java
@@ -1,10 +1,11 @@
 package com.canvas.domain.diary.entity;
 
 import com.canvas.domain.common.DomainId;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public class Image {
     private DomainId id;

--- a/Domain-Module/src/main/java/com/canvas/domain/user/entity/User.java
+++ b/Domain-Module/src/main/java/com/canvas/domain/user/entity/User.java
@@ -2,14 +2,19 @@ package com.canvas.domain.user.entity;
 
 import com.canvas.domain.common.DomainId;
 import com.canvas.domain.user.enums.SocialLoginProvider;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public class User {
-    private final DomainId domainId;
-    private final String username;
-    private final String socialId;
-    private final SocialLoginProvider socialLoginProvider;
+    private DomainId id;
+    private String username;
+    private String socialId;
+    private SocialLoginProvider socialLoginProvider;
+
+    public static User create(DomainId id, String username, String socialId, SocialLoginProvider socialLoginProvider) {
+        return new User(id, username, socialId, socialLoginProvider);
+    }
 }

--- a/Domain-Module/src/main/java/com/canvas/domain/user/entity/UserToken.java
+++ b/Domain-Module/src/main/java/com/canvas/domain/user/entity/UserToken.java
@@ -1,13 +1,18 @@
 package com.canvas.domain.user.entity;
 
 import com.canvas.domain.common.DomainId;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public class UserToken {
     private final DomainId domainId;
     private final String token;
     private final DomainId userId;
+
+    public static UserToken create(DomainId domainId, String token, DomainId userId) {
+        return new UserToken(domainId, token, userId);
+    }
 }

--- a/Domain-Module/src/test/java/com/canvas/domain/diary/entity/DiaryCompleteTest.java
+++ b/Domain-Module/src/test/java/com/canvas/domain/diary/entity/DiaryCompleteTest.java
@@ -1,0 +1,95 @@
+package com.canvas.domain.diary.entity;
+
+import com.canvas.domain.diary.enums.Emotion;
+import com.canvas.domain.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.canvas.domain.diary.enums.Emotion.DISGUST;
+import static com.canvas.domain.fixture.DiaryFixture.PUBLIC_MY_DIARY;
+import static com.canvas.domain.fixture.DiaryFixture.PUBLIC_OTHER_DIARY;
+import static com.canvas.domain.fixture.UserFixture.MYSELF;
+import static com.canvas.domain.fixture.UserFixture.OTHER1;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DiaryCompleteTest {
+
+    @Test
+    @DisplayName("일기 내용 업데이트")
+    void updateDiaryContentTest() {
+        // given
+        DiaryComplete diary = PUBLIC_MY_DIARY.getDiaryComplete();
+
+        String newContent = "내용1 수정";
+        Emotion newEmotion = DISGUST;
+
+        // when
+        diary.updateDiaryContent(newContent, newEmotion);
+
+        // then
+        assertThat(diary.getContent()).isEqualTo(newContent);
+        assertThat(diary.getEmotion()).isEqualTo(newEmotion);
+    }
+
+    @Test
+    @DisplayName("일기 공개 범위 업데이트")
+    void updatePublicTest() {
+        // given
+        DiaryComplete diary = PUBLIC_MY_DIARY.getDiaryComplete();
+        boolean newPublic = false;
+
+        // when
+        diary.updatePublic(newPublic);
+
+        // then
+        assertThat(diary.getIsPublic()).isEqualTo(newPublic);
+    }
+
+    @Test
+    @DisplayName("좋아요 개수 반환")
+    void getLikeCountTest() {
+        // given
+        DiaryComplete diary = PUBLIC_MY_DIARY.getDiaryComplete();
+
+        // when
+        int likeCount = diary.getLikeCount();
+
+        // then
+        assertThat(likeCount).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("좋아요 여부 반환")
+    void isLikedTest() {
+        // given
+        DiaryComplete diary = PUBLIC_OTHER_DIARY.getDiaryComplete();
+        User myself = MYSELF.getUser();
+        User other1 = OTHER1.getUser();
+
+        // when
+        boolean isLiked = diary.isLiked(myself.getId());
+        boolean isNotLiked = diary.isLiked(other1.getId());
+
+        // then
+        assertThat(isLiked).isTrue();
+        assertThat(isNotLiked).isFalse();
+    }
+
+    @Test
+    @DisplayName("글쓴이 여부 반환")
+    void isWriterTest() {
+        // given
+        DiaryComplete diary = PUBLIC_MY_DIARY.getDiaryComplete();
+        User myself = MYSELF.getUser();
+        User other1 = OTHER1.getUser();
+
+        // when
+        boolean isWriter = diary.isWriter(myself.getId());
+        boolean isNotWriter = diary.isWriter(other1.getId());
+
+        // then
+        assertThat(isWriter).isTrue();
+        assertThat(isNotWriter).isFalse();
+    }
+
+}

--- a/Domain-Module/src/test/java/com/canvas/domain/diary/entity/DiaryOverviewTest.java
+++ b/Domain-Module/src/test/java/com/canvas/domain/diary/entity/DiaryOverviewTest.java
@@ -1,0 +1,41 @@
+package com.canvas.domain.diary.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.canvas.domain.fixture.DiaryFixture.NO_MAIN_IMAGE_DIARY;
+import static com.canvas.domain.fixture.DiaryFixture.PUBLIC_OTHER_DIARY;
+import static com.canvas.domain.fixture.ImageFixture.PUBLIC_OTHER_DIARY_IMAGE2;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DiaryOverviewTest {
+    
+    @Test
+    @DisplayName("메인 이미지 URL 반환")
+    void getMainImageTest() {
+        // given
+        DiaryOverview diary = PUBLIC_OTHER_DIARY.getDiaryOverview();
+        Image mainImage = PUBLIC_OTHER_DIARY_IMAGE2.getImage();
+
+        // when
+        String imageUrl = diary.getMainImageOrDefault();
+
+        // then
+        assertThat(imageUrl).isEqualTo(mainImage.getImageUrl());
+    }
+
+    @Test
+    @DisplayName("기본 이미지 URL 반환")
+    void getDefaultTest() {
+        // given
+        DiaryOverview diary = NO_MAIN_IMAGE_DIARY.getDiaryOverview();
+        String defaultImageUrl = Image.DEFAULT_IMAGE_URL;
+
+        // when
+        String imageUrl = diary.getMainImageOrDefault();
+
+        // then
+        assertThat(imageUrl).isEqualTo(defaultImageUrl);
+    }
+
+}

--- a/Domain-Module/src/test/java/com/canvas/domain/diary/entity/ImageTest.java
+++ b/Domain-Module/src/test/java/com/canvas/domain/diary/entity/ImageTest.java
@@ -1,0 +1,42 @@
+package com.canvas.domain.diary.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.canvas.domain.fixture.ImageFixture.PUBLIC_MY_DIARY_IMAGE1;
+import static com.canvas.domain.fixture.ImageFixture.PUBLIC_MY_DIARY_IMAGE2;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ImageTest {
+    @Test
+    @DisplayName("메인 이미지 업데이트")
+    void updateMainTest() {
+        // given
+        Image image1 = PUBLIC_MY_DIARY_IMAGE1.getImage();
+        Image image2 = PUBLIC_MY_DIARY_IMAGE2.getImage();
+
+        // when
+        image1.updateMain(false);
+        image2.updateMain(true);
+
+        // then
+        assertThat(image1.isMain()).isFalse();
+        assertThat(image2.isMain()).isTrue();
+    }
+
+    @Test
+    @DisplayName("메인 이미지 여부 반환")
+    void isMainTest() {
+        // given
+        Image image1 = PUBLIC_MY_DIARY_IMAGE1.getImage();
+        Image image2 = PUBLIC_MY_DIARY_IMAGE2.getImage();
+
+        // when
+        Boolean isMain1 = image1.isMain();
+        Boolean isMain2 = image2.isMain();
+
+        // then
+        assertThat(isMain1).isTrue();
+        assertThat(isMain2).isFalse();
+    }
+}

--- a/Domain-Module/src/testFixtures/java/com/canvas/domain/builder/DiaryBasicBuilder.java
+++ b/Domain-Module/src/testFixtures/java/com/canvas/domain/builder/DiaryBasicBuilder.java
@@ -1,0 +1,57 @@
+package com.canvas.domain.builder;
+
+import com.canvas.domain.common.DomainId;
+import com.canvas.domain.diary.entity.DiaryBasic;
+import com.canvas.domain.diary.enums.Emotion;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class DiaryBasicBuilder {
+    private DomainId id;
+    private DomainId writerId;
+    private String content;
+    private Emotion emotion;
+    private LocalDate date;
+    private LocalDateTime createdAt;
+    private Boolean isPublic;
+
+    public DiaryBasicBuilder id(DomainId id) {
+        this.id = id;
+        return this;
+    }
+
+    public DiaryBasicBuilder writerId(DomainId writerId) {
+        this.writerId = writerId;
+        return this;
+    }
+
+    public DiaryBasicBuilder content(String content) {
+        this.content = content;
+        return this;
+    }
+
+    public DiaryBasicBuilder emotion(Emotion emotion) {
+        this.emotion = emotion;
+        return this;
+    }
+
+    public DiaryBasicBuilder date(LocalDate date) {
+        this.date = date;
+        return this;
+    }
+
+    public DiaryBasicBuilder createdAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+        return this;
+    }
+
+    public DiaryBasicBuilder isPublic(Boolean isPublic) {
+        this.isPublic = isPublic;
+        return this;
+    }
+
+    public DiaryBasic build() {
+        return DiaryBasic.create(id, writerId, content, emotion, date, createdAt, isPublic);
+    }
+}

--- a/Domain-Module/src/testFixtures/java/com/canvas/domain/builder/DiaryCompleteBuilder.java
+++ b/Domain-Module/src/testFixtures/java/com/canvas/domain/builder/DiaryCompleteBuilder.java
@@ -1,0 +1,73 @@
+package com.canvas.domain.builder;
+
+import com.canvas.domain.common.DomainId;
+import com.canvas.domain.diary.entity.DiaryComplete;
+import com.canvas.domain.diary.entity.Image;
+import com.canvas.domain.diary.entity.Like;
+import com.canvas.domain.diary.enums.Emotion;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class DiaryCompleteBuilder {
+    private DomainId id;
+    private DomainId writerId;
+    private String content;
+    private Emotion emotion;
+    private LocalDate date;
+    private LocalDateTime createdAt;
+    private Boolean isPublic;
+    private List<Image> images;
+    private List<Like> likes;
+
+    public DiaryCompleteBuilder id(DomainId id) {
+        this.id = id;
+        return this;
+    }
+
+    public DiaryCompleteBuilder writerId(DomainId writerId) {
+        this.writerId = writerId;
+        return this;
+    }
+
+    public DiaryCompleteBuilder content(String content) {
+        this.content = content;
+        return this;
+    }
+
+    public DiaryCompleteBuilder emotion(Emotion emotion) {
+        this.emotion = emotion;
+        return this;
+    }
+
+    public DiaryCompleteBuilder date(LocalDate date) {
+        this.date = date;
+        return this;
+    }
+
+    public DiaryCompleteBuilder createdAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+        return this;
+    }
+
+    public DiaryCompleteBuilder isPublic(Boolean isPublic) {
+        this.isPublic = isPublic;
+        return this;
+    }
+
+    public DiaryCompleteBuilder images(List<Image> images) {
+        this.images = images;
+        return this;
+    }
+
+    public DiaryCompleteBuilder likes(List<Like> likes) {
+        this.likes = likes;
+        return this;
+    }
+
+    public DiaryComplete build() {
+        return DiaryComplete.create(id, writerId, content, emotion, date, createdAt, isPublic, images, likes);
+    }
+
+}

--- a/Domain-Module/src/testFixtures/java/com/canvas/domain/builder/DiaryOverviewBuilder.java
+++ b/Domain-Module/src/testFixtures/java/com/canvas/domain/builder/DiaryOverviewBuilder.java
@@ -1,0 +1,65 @@
+package com.canvas.domain.builder;
+
+import com.canvas.domain.common.DomainId;
+import com.canvas.domain.diary.entity.DiaryOverview;
+import com.canvas.domain.diary.entity.Image;
+import com.canvas.domain.diary.enums.Emotion;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class DiaryOverviewBuilder {
+    private DomainId id;
+    private DomainId writerId;
+    private String content;
+    private Emotion emotion;
+    private LocalDate date;
+    private LocalDateTime createdAt;
+    private Boolean isPublic;
+    private List<Image> images;
+
+    public DiaryOverviewBuilder id(DomainId id) {
+        this.id = id;
+        return this;
+    }
+
+    public DiaryOverviewBuilder writerId(DomainId writerId) {
+        this.writerId = writerId;
+        return this;
+    }
+
+    public DiaryOverviewBuilder content(String content) {
+        this.content = content;
+        return this;
+    }
+
+    public DiaryOverviewBuilder emotion(Emotion emotion) {
+        this.emotion = emotion;
+        return this;
+    }
+
+    public DiaryOverviewBuilder date(LocalDate date) {
+        this.date = date;
+        return this;
+    }
+
+    public DiaryOverviewBuilder createdAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+        return this;
+    }
+
+    public DiaryOverviewBuilder isPublic(Boolean isPublic) {
+        this.isPublic = isPublic;
+        return this;
+    }
+
+    public DiaryOverviewBuilder images(List<Image> images) {
+        this.images = images;
+        return this;
+    }
+
+    public DiaryOverview build() {
+        return DiaryOverview.create(id, writerId, content, emotion, date, createdAt, isPublic, images);
+    }
+}

--- a/Domain-Module/src/testFixtures/java/com/canvas/domain/builder/ImageBuilder.java
+++ b/Domain-Module/src/testFixtures/java/com/canvas/domain/builder/ImageBuilder.java
@@ -1,0 +1,35 @@
+package com.canvas.domain.builder;
+
+import com.canvas.domain.common.DomainId;
+import com.canvas.domain.diary.entity.Image;
+
+public class ImageBuilder {
+    private DomainId id;
+    private DomainId diaryId;
+    private Boolean isMain;
+    private String imageUrl;
+
+    public ImageBuilder id(DomainId id) {
+        this.id = id;
+        return this;
+    }
+
+    public ImageBuilder diaryId(DomainId diaryId) {
+        this.diaryId = diaryId;
+        return this;
+    }
+
+    public ImageBuilder isMain(Boolean isMain) {
+        this.isMain = isMain;
+        return this;
+    }
+
+    public ImageBuilder imageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+        return this;
+    }
+
+    public Image build() {
+        return Image.create(id, diaryId, isMain, imageUrl);
+    }
+}

--- a/Domain-Module/src/testFixtures/java/com/canvas/domain/builder/LikeBuilder.java
+++ b/Domain-Module/src/testFixtures/java/com/canvas/domain/builder/LikeBuilder.java
@@ -1,0 +1,29 @@
+package com.canvas.domain.builder;
+
+import com.canvas.domain.common.DomainId;
+import com.canvas.domain.diary.entity.Like;
+
+public class LikeBuilder {
+    private DomainId id;
+    private DomainId userId;
+    private DomainId diaryId;
+
+    public LikeBuilder id(DomainId id) {
+        this.id = id;
+        return this;
+    }
+
+    public LikeBuilder userId(DomainId userId) {
+        this.userId = userId;
+        return this;
+    }
+
+    public LikeBuilder diaryId(DomainId diaryId) {
+        this.diaryId = diaryId;
+        return this;
+    }
+
+    public Like build() {
+        return Like.create(id, userId, diaryId);
+    }
+}

--- a/Domain-Module/src/testFixtures/java/com/canvas/domain/builder/UserBuilder.java
+++ b/Domain-Module/src/testFixtures/java/com/canvas/domain/builder/UserBuilder.java
@@ -1,0 +1,36 @@
+package com.canvas.domain.builder;
+
+import com.canvas.domain.common.DomainId;
+import com.canvas.domain.user.entity.User;
+import com.canvas.domain.user.enums.SocialLoginProvider;
+
+public class UserBuilder {
+    private DomainId id;
+    private String username;
+    private String socialId;
+    private SocialLoginProvider socialLoginProvider;
+
+    public UserBuilder id(DomainId id) {
+        this.id = id;
+        return this;
+    }
+
+    public UserBuilder username(String username) {
+        this.username = username;
+        return this;
+    }
+
+    public UserBuilder socialId(String socialId) {
+        this.socialId = socialId;
+        return this;
+    }
+
+    public UserBuilder socialLoginProvider(SocialLoginProvider socialLoginProvider) {
+        this.socialLoginProvider = socialLoginProvider;
+        return this;
+    }
+
+    public User build() {
+        return User.create(id, username, socialId, socialLoginProvider);
+    }
+}

--- a/Domain-Module/src/testFixtures/java/com/canvas/domain/fixture/DiaryFixture.java
+++ b/Domain-Module/src/testFixtures/java/com/canvas/domain/fixture/DiaryFixture.java
@@ -1,0 +1,122 @@
+package com.canvas.domain.fixture;
+
+import com.canvas.domain.builder.DiaryBasicBuilder;
+import com.canvas.domain.builder.DiaryCompleteBuilder;
+import com.canvas.domain.builder.DiaryOverviewBuilder;
+import com.canvas.domain.common.DomainId;
+import com.canvas.domain.diary.entity.DiaryBasic;
+import com.canvas.domain.diary.entity.DiaryComplete;
+import com.canvas.domain.diary.entity.DiaryOverview;
+import com.canvas.domain.diary.enums.Emotion;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+
+import static com.canvas.domain.diary.enums.Emotion.*;
+import static com.canvas.domain.fixture.UserFixture.*;
+
+public enum DiaryFixture {
+    PUBLIC_MY_DIARY(
+            "내용1",
+            JOY,
+            LocalDate.of(2024, 10, 15),
+            LocalDateTime.now(),
+            true,
+            MYSELF
+    ),
+    PUBLIC_OTHER_DIARY(
+            "내용2",
+            ANGER,
+            LocalDate.of(2024, 10, 17),
+            LocalDateTime.now(),
+            true,
+            OTHER1
+    ),
+    PRIVATE_OTHER_DIARY(
+            "내용3",
+            SADNESS,
+            LocalDate.of(2024, 10, 31),
+            LocalDateTime.now(),
+            false,
+            OTHER2
+    );
+
+    @Getter
+    private final DomainId id;
+    private final String content;
+    private final Emotion emotion;
+    private final LocalDate date;
+    private final LocalDateTime createdAt;
+    private final Boolean isPublic;
+    private final UserFixture userFixture;
+
+    DiaryFixture(
+            String content,
+            Emotion emotion,
+            LocalDate date,
+            LocalDateTime createdAt,
+            Boolean isPublic,
+            UserFixture userFixture
+    ) {
+        this.id = DomainId.generate();
+        this.content = content;
+        this.emotion = emotion;
+        this.date = date;
+        this.createdAt = createdAt;
+        this.isPublic = isPublic;
+        this.userFixture = userFixture;
+    }
+
+    public DiaryBasic getDiaryBasie() {
+        return new DiaryBasicBuilder()
+                .id(id)
+                .writerId(userFixture.getId())
+                .content(content)
+                .emotion(emotion)
+                .date(date)
+                .createdAt(createdAt)
+                .isPublic(isPublic)
+                .build();
+    }
+
+    public DiaryOverview getDiaryOverview() {
+        return new DiaryOverviewBuilder()
+                .id(id)
+                .writerId(userFixture.getId())
+                .content(content)
+                .emotion(emotion)
+                .date(date)
+                .createdAt(createdAt)
+                .isPublic(isPublic)
+                .images(
+                        Arrays.stream(ImageFixture.values())
+                                .filter(imageFixture -> imageFixture.getDiaryFixture().equals(this))
+                                .map(ImageFixture::getImage)
+                                .toList())
+                .build();
+    }
+
+    public DiaryComplete getDiaryComplete() {
+        return new DiaryCompleteBuilder()
+                .id(id)
+                .writerId(userFixture.getId())
+                .content(content)
+                .emotion(emotion)
+                .date(date)
+                .createdAt(createdAt)
+                .isPublic(isPublic)
+                .images(
+                        Arrays.stream(ImageFixture.values())
+                                .filter(imageFixture -> imageFixture.getDiaryFixture().equals(this))
+                                .map(ImageFixture::getImage)
+                                .toList())
+                .likes(
+                        Arrays.stream(LikeFixture.values())
+                                .filter(likeFixture -> likeFixture.getDiaryFixture().equals(this))
+                                .map(LikeFixture::getLike)
+                                .toList())
+                .build();
+    }
+}

--- a/Domain-Module/src/testFixtures/java/com/canvas/domain/fixture/DiaryFixture.java
+++ b/Domain-Module/src/testFixtures/java/com/canvas/domain/fixture/DiaryFixture.java
@@ -41,6 +41,14 @@ public enum DiaryFixture {
             LocalDateTime.now(),
             false,
             OTHER2
+    ),
+    NO_MAIN_IMAGE_DIARY(
+            "내용4",
+            FEAR,
+            LocalDate.of(2024, 11, 1),
+            LocalDateTime.now(),
+            true,
+            MYSELF
     );
 
     @Getter

--- a/Domain-Module/src/testFixtures/java/com/canvas/domain/fixture/DiaryFixture.java
+++ b/Domain-Module/src/testFixtures/java/com/canvas/domain/fixture/DiaryFixture.java
@@ -13,6 +13,7 @@ import lombok.Getter;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.List;
 
 import static com.canvas.domain.diary.enums.Emotion.*;
 import static com.canvas.domain.fixture.UserFixture.*;
@@ -126,5 +127,20 @@ public enum DiaryFixture {
                                 .map(LikeFixture::getLike)
                                 .toList())
                 .build();
+    }
+
+    public static List<DiaryBasic> getAllDiaryBasicByUser(UserFixture userFixture) {
+        return Arrays.stream(DiaryFixture.values())
+                .filter(diaryFixture -> diaryFixture.userFixture.equals(userFixture))
+                .map(DiaryFixture::getDiaryBasie)
+                .toList();
+    }
+
+    public static List<DiaryOverview> getLikedDiaries(UserFixture userFixture) {
+        return Arrays.stream(LikeFixture.values())
+                .filter(likeFixture -> likeFixture.getUserFixture().equals(userFixture))
+                .map(LikeFixture::getDiaryFixture)
+                .map(DiaryFixture::getDiaryOverview)
+                .toList();
     }
 }

--- a/Domain-Module/src/testFixtures/java/com/canvas/domain/fixture/ImageFixture.java
+++ b/Domain-Module/src/testFixtures/java/com/canvas/domain/fixture/ImageFixture.java
@@ -1,0 +1,43 @@
+package com.canvas.domain.fixture;
+
+import com.canvas.domain.builder.ImageBuilder;
+import com.canvas.domain.common.DomainId;
+import com.canvas.domain.diary.entity.Image;
+import lombok.Getter;
+
+import static com.canvas.domain.fixture.DiaryFixture.*;
+
+public enum ImageFixture {
+    PUBLIC_MY_DIARY_IMAGE1(true, "url1", PUBLIC_MY_DIARY),
+    PUBLIC_MY_DIARY_IMAGE2(false, "url2", PUBLIC_MY_DIARY),
+    PUBLIC_MY_DIARY_IMAGE3(false, "url3", PUBLIC_MY_DIARY),
+    PUBLIC_OTHER_DIARY_IMAGE1(false, "url4", PUBLIC_OTHER_DIARY),
+    PUBLIC_OTHER_DIARY_IMAGE2(true, "url5", PUBLIC_OTHER_DIARY),
+    PRIVATE_OTHER_DIARY_IMAGE1(true, "url6", PRIVATE_OTHER_DIARY);
+
+    private final DomainId id;
+    private final Boolean isMain;
+    private final String imageUrl;
+    @Getter
+    private final DiaryFixture diaryFixture;
+
+    ImageFixture(
+            Boolean isMain,
+            String imageUrl,
+            DiaryFixture diaryFixture
+    ) {
+        this.id = DomainId.generate();
+        this.isMain = isMain;
+        this.imageUrl = imageUrl;
+        this.diaryFixture = diaryFixture;
+    }
+
+    public Image getImage() {
+        return new ImageBuilder()
+                .id(id)
+                .isMain(isMain)
+                .imageUrl(imageUrl)
+                .diaryId(diaryFixture.getId())
+                .build();
+    }
+}

--- a/Domain-Module/src/testFixtures/java/com/canvas/domain/fixture/LikeFixture.java
+++ b/Domain-Module/src/testFixtures/java/com/canvas/domain/fixture/LikeFixture.java
@@ -16,6 +16,7 @@ public enum LikeFixture {
     PUBLIC_OTHER_DIARY_LIKE2(OTHER2, PUBLIC_OTHER_DIARY);
 
     private final DomainId id;
+    @Getter
     private final UserFixture userFixture;
     @Getter
     private final DiaryFixture diaryFixture;

--- a/Domain-Module/src/testFixtures/java/com/canvas/domain/fixture/LikeFixture.java
+++ b/Domain-Module/src/testFixtures/java/com/canvas/domain/fixture/LikeFixture.java
@@ -1,0 +1,36 @@
+package com.canvas.domain.fixture;
+
+import com.canvas.domain.builder.LikeBuilder;
+import com.canvas.domain.common.DomainId;
+import com.canvas.domain.diary.entity.Like;
+import lombok.Getter;
+
+import static com.canvas.domain.fixture.DiaryFixture.*;
+import static com.canvas.domain.fixture.UserFixture.*;
+
+public enum LikeFixture {
+    PUBLIC_MY_DIARY_LIKE1(MYSELF, PUBLIC_MY_DIARY),
+    PUBLIC_MY_DIARY_LIKE2(OTHER1, PUBLIC_MY_DIARY),
+    PUBLIC_MY_DIARY_LIKE3(OTHER2, PUBLIC_MY_DIARY),
+    PUBLIC_OTHER_DIARY_LIKE1(MYSELF, PUBLIC_OTHER_DIARY),
+    PUBLIC_OTHER_DIARY_LIKE2(OTHER2, PUBLIC_OTHER_DIARY);
+
+    private final DomainId id;
+    private final UserFixture userFixture;
+    @Getter
+    private final DiaryFixture diaryFixture;
+
+    LikeFixture(UserFixture userFixture, DiaryFixture diaryFixture) {
+        this.id = DomainId.generate();
+        this.userFixture = userFixture;
+        this.diaryFixture = diaryFixture;
+    }
+
+    public Like getLike() {
+        return new LikeBuilder()
+                .id(id)
+                .userId(userFixture.getId())
+                .diaryId(diaryFixture.getId())
+                .build();
+    }
+}

--- a/Domain-Module/src/testFixtures/java/com/canvas/domain/fixture/UserFixture.java
+++ b/Domain-Module/src/testFixtures/java/com/canvas/domain/fixture/UserFixture.java
@@ -1,0 +1,36 @@
+package com.canvas.domain.fixture;
+
+import com.canvas.domain.builder.UserBuilder;
+import com.canvas.domain.common.DomainId;
+import com.canvas.domain.user.entity.User;
+import com.canvas.domain.user.enums.SocialLoginProvider;
+import lombok.Getter;
+
+public enum UserFixture {
+
+    MYSELF("mySocialId", "myUsername", SocialLoginProvider.KAKAO),
+    OTHER1("socialId1", "username1", SocialLoginProvider.KAKAO),
+    OTHER2("socialId2", "username2", SocialLoginProvider.KAKAO);
+
+    @Getter
+    private final DomainId id;
+    private final String socialId;
+    private final String username;
+    private final SocialLoginProvider socialLoginProvider;
+
+    UserFixture(String socialId, String username, SocialLoginProvider socialLoginProvider) {
+        this.id = DomainId.generate();
+        this.socialId = socialId;
+        this.username = username;
+        this.socialLoginProvider = socialLoginProvider;
+    }
+
+    public User getUser() {
+        return new UserBuilder()
+                .id(id)
+                .socialId(socialId)
+                .username(username)
+                .socialLoginProvider(socialLoginProvider)
+                .build();
+    }
+}

--- a/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/DiaryContentConvertGeminiAdapter.java
+++ b/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/DiaryContentConvertGeminiAdapter.java
@@ -1,6 +1,7 @@
 package com.canvas.google.gemini;
 
 import com.canvas.application.diary.port.out.DiaryEmotionExtractPort;
+import com.canvas.application.diary.port.out.DiaryKeywordExtractPort;
 import com.canvas.application.image.port.out.ImagePromptGeneratePort;
 import com.canvas.domain.diary.enums.Emotion;
 import com.canvas.google.gemini.service.GeminiPromptConsts;
@@ -9,11 +10,14 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.util.Arrays;
+import java.util.List;
+
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class DiaryContentConvertGeminiAdapter
-        implements DiaryEmotionExtractPort, ImagePromptGeneratePort {
+        implements DiaryEmotionExtractPort, ImagePromptGeneratePort, DiaryKeywordExtractPort {
 
     private final GeminiService geminiService;
 
@@ -26,5 +30,11 @@ public class DiaryContentConvertGeminiAdapter
     @Override
     public String generatePrompt(String content) {
         return geminiService.generate(GeminiPromptConsts.IMAGE_GENERATOR + content);
+    }
+
+    @Override
+    public List<String> keywordExtract(String content) {
+        String response = geminiService.generate(GeminiPromptConsts.KEYWORD_EXTRACT + content);
+        return Arrays.stream(response.split(", ")).toList();
     }
 }

--- a/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/DiaryContentConvertGeminiAdapter.java
+++ b/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/DiaryContentConvertGeminiAdapter.java
@@ -20,7 +20,6 @@ public class DiaryContentConvertGeminiAdapter
     @Override
     public Emotion emotionExtract(String content) {
         String emotion = geminiService.generate(GeminiPromptConsts.EMOTION_EXTRACT + content);
-        log.info("emotion={}", emotion);
         return Emotion.parse(emotion);
     }
 

--- a/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/DiaryContentConvertGeminiAdapter.java
+++ b/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/DiaryContentConvertGeminiAdapter.java
@@ -4,8 +4,8 @@ import com.canvas.application.diary.port.out.DiaryEmotionExtractPort;
 import com.canvas.application.diary.port.out.DiaryKeywordExtractPort;
 import com.canvas.application.image.port.out.ImagePromptGeneratePort;
 import com.canvas.domain.diary.enums.Emotion;
-import com.canvas.google.gemini.service.GeminiPromptConsts;
-import com.canvas.google.gemini.service.GeminiService;
+import com.canvas.google.gemini.service.LLMPromptConsts;
+import com.canvas.google.gemini.service.LLMService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -19,22 +19,22 @@ import java.util.List;
 public class DiaryContentConvertGeminiAdapter
         implements DiaryEmotionExtractPort, ImagePromptGeneratePort, DiaryKeywordExtractPort {
 
-    private final GeminiService geminiService;
+    private final LLMService llmService;
 
     @Override
     public Emotion emotionExtract(String content) {
-        String emotion = geminiService.generate(GeminiPromptConsts.EMOTION_EXTRACT + content);
+        String emotion = llmService.generate(LLMPromptConsts.EMOTION_EXTRACT + content);
         return Emotion.parse(emotion);
     }
 
     @Override
     public String generatePrompt(String content) {
-        return geminiService.generate(GeminiPromptConsts.IMAGE_GENERATOR + content);
+        return llmService.generate(LLMPromptConsts.IMAGE_GENERATOR + content);
     }
 
     @Override
     public List<String> keywordExtract(String content) {
-        String response = geminiService.generate(GeminiPromptConsts.KEYWORD_EXTRACT + content);
+        String response = llmService.generate(LLMPromptConsts.KEYWORD_EXTRACT + content);
         return Arrays.stream(response.split(", ")).toList();
     }
 }

--- a/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/exception/GeminiException.java
+++ b/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/exception/GeminiException.java
@@ -1,19 +1,33 @@
 package com.canvas.google.gemini.exception;
 
-// TODO - 공통 커스텀 예외로 리팩토링 필요
-public class GeminiException extends IllegalArgumentException {
+import com.canvas.common.exception.BusinessException;
+import org.springframework.http.HttpStatus;
 
-    public GeminiException(String s) {
-        super(s);
+public class GeminiException extends BusinessException {
+
+    private static final String CODE_PREFIX = "GEMINI";
+    private static final String DEFAULT_MESSAGE = "Gemini 예외가 발생했습니다.";
+    private static final HttpStatus DEFAULT_HTTP_STATUS = HttpStatus.BAD_REQUEST;
+
+    public GeminiException() {
+        super(CODE_PREFIX, 0, DEFAULT_HTTP_STATUS, DEFAULT_MESSAGE);
+    }
+
+    public GeminiException(int errorCode, HttpStatus httpStatus, String message) {
+        super(CODE_PREFIX, errorCode, httpStatus, message);
     }
 
     public static class GeminiSafetyException extends GeminiException {
         public GeminiSafetyException() {
-            super("유해한 프롬프트");
-        }
-
-        public GeminiSafetyException(String s) {
-            super(s);
+            super(1, HttpStatus.BAD_REQUEST, "유해한 내용입니다.");
         }
     }
+
+    public static class GeminiTooManyRequestsException extends GeminiException {
+        public GeminiTooManyRequestsException() {
+            super(2, HttpStatus.TOO_MANY_REQUESTS, "요청이 너무 많습니다.");
+        }
+    }
+
+
 }

--- a/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/exception/GptException.java
+++ b/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/exception/GptException.java
@@ -1,0 +1,32 @@
+package com.canvas.google.gemini.exception;
+
+import com.canvas.common.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class GptException extends BusinessException {
+
+  private static final String CODE_PREFIX = "GPT";
+  private static final String DEFAULT_MESSAGE = "GPT 예외가 발생했습니다.";
+  private static final HttpStatus DEFAULT_HTTP_STATUS = HttpStatus.BAD_REQUEST;
+
+  public GptException() {
+    super(CODE_PREFIX, 0, DEFAULT_HTTP_STATUS, DEFAULT_MESSAGE);
+  }
+
+  public GptException(int errorCode, HttpStatus httpStatus, String message) {
+    super(CODE_PREFIX, errorCode, httpStatus, message);
+  }
+
+  public static class GptSafetyException extends GptException {
+    public GptSafetyException() {
+      super(1, HttpStatus.BAD_REQUEST, "유해한 내용입니다.");
+    }
+  }
+
+  public static class GptTooManyRequestsException extends GptException {
+    public GptTooManyRequestsException() {
+      super(2, HttpStatus.TOO_MANY_REQUESTS, "요청이 너무 많습니다.");
+    }
+  }
+
+}

--- a/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/service/GeminiPromptConsts.java
+++ b/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/service/GeminiPromptConsts.java
@@ -2,14 +2,12 @@ package com.canvas.google.gemini.service;
 
 public class GeminiPromptConsts {
     public static final String IMAGE_GENERATOR = """
-            다음 일기 내용에서 유해하지 않은 가장 중요한 장면을 하나만 정하고, 그 주요 장면을 구체적으로 설명하는 문장을
-            이미지 생성형 AI의 프롬프트에 적합하게 만들어. 제목은 출력하지 말고 그 프롬프트 내용만 영문으로 출력해.
+            Choose only one of the most important scenes in the following content, and make a sentence that specifically describes the main scene suitable for the prompt in the image Generative AI. If the contents are inappropriate, print FORBIDDEN. Don't print the title, just print the contents of the prompt in English.
             
             """;
 
     public static final String EMOTION_EXTRACT = """
-            다음 일기 내용에서 가장 주된 감정을 ANGER, SADNESS, JOY, FEAR, DISGUST, SHAME, SURPRISE, CURIOSITY
-            중 하나만 골라서 한 단어로만 출력해. 감정이 잘 드러나지 않거나 목록에 없다면 NONE을 출력해.
+            Choose one of ANGER, SADNESS, JOY, FEAR, DISGUST, SHAME, SURPRISE, CURIOSITY, and print out the main emotions in the following diary contents in just one word. If the contents are inappropriate, print FORBIDDEN, and if the emotions are not clearly visible or listed, print NONE.
             
             """;
 }

--- a/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/service/GeminiPromptConsts.java
+++ b/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/service/GeminiPromptConsts.java
@@ -10,4 +10,8 @@ public class GeminiPromptConsts {
             Choose one of ANGER, SADNESS, JOY, FEAR, DISGUST, SHAME, SURPRISE, CURIOSITY, and print out the main emotions in the following diary contents in just one word. If the contents are inappropriate, print FORBIDDEN, and if the emotions are not clearly visible or listed, print NONE.
             
             """;
+
+    public static final String KEYWORD_EXTRACT = """
+            일기에서 가장 핵심적인 키워드를 1~5개를 뽑아줘. 정확히 이 형식에 맞춰 뽑아줘 "keyword1, keyword2, keyword3, keyword4, keyword5"
+            """;
 }

--- a/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/service/GeminiService.java
+++ b/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/service/GeminiService.java
@@ -16,7 +16,7 @@ import java.util.Objects;
 
 @Component
 @Slf4j
-public class GeminiService {
+public class GeminiService implements LLMService{
 
     @Value("${gemini.api-key}")
     private String API_KEY;
@@ -48,6 +48,8 @@ public class GeminiService {
                         .block())
                 .getText();
     }
+
+
 
     public record Request(
             List<Content> contents

--- a/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/service/GptService.java
+++ b/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/service/GptService.java
@@ -1,0 +1,100 @@
+package com.canvas.google.gemini.service;
+
+import com.canvas.google.gemini.exception.GptException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.util.retry.Retry;
+
+import java.time.Duration;
+import java.util.List;
+
+@Primary
+@Component
+@Slf4j
+public class GptService implements LLMService{
+
+    @Value("${openai.api-key}")
+    private String apiKey;
+
+    private final WebClient webClient = WebClient.create("https://api.openai.com/v1/chat/completions");
+
+    public String generate(String prompt) {
+        Response response = webClient.post()
+                .uri("")
+                .header("Authorization", "Bearer " + apiKey)
+                .header("Accept", "application/json")
+                .bodyValue(Request.of(prompt))
+                .retrieve()
+                .bodyToMono(Response.class)
+                .doOnNext(res -> {
+                    log.info(res.getReason());
+                    if (res.getReason().equals("null")) {
+                        throw new NullPointerException("응답 오류");
+                    }
+                    else if (!res.getReason().equals("stop")) {
+                        throw new GptException();
+                    }
+                })
+                .retryWhen(
+                        Retry.fixedDelay(3, Duration.ofSeconds(3))
+                                .filter(throwable -> throwable instanceof NullPointerException)
+                )
+                .doOnError(error -> {
+                    if (error instanceof NullPointerException) {
+                        throw new GptException.GptTooManyRequestsException();
+                    }
+                    throw new GptException();
+                })
+                .block();
+        log.info("{}", response.usage().total_tokens());
+        return response.getContent();
+    }
+
+    public record Request(
+            String model,
+            List<Message> messages,
+            Double temperature,
+            Integer max_tokens
+    ) {
+        public static Request of(String prompt) {
+            return new Request(
+                    "gpt-4o-mini",
+                    List.of(
+                            new Message("user", prompt)
+                    ),
+                    0.7,
+                    300
+            );
+        }
+
+        public record Message(String role, String content) {}
+    }
+
+    public record Response(
+            List<Choice> choices,
+            Usage usage
+    ) {
+
+        public String getContent() {
+            return choices.get(0).message().content().trim();
+        }
+        public String getReason() {
+            return choices.get(0).finish_reason();
+        }
+
+        public record Choice(
+                Message message,
+                String finish_reason            //  stop: 정상, length: 토큰 초과, content_filter: 부적절, null: 모델 오류
+        ) {
+            public record Message(
+                    String content
+            ) {}
+        }
+        public record Usage(
+                Integer total_tokens
+        ) {}
+    }
+}

--- a/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/service/LLMPromptConsts.java
+++ b/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/service/LLMPromptConsts.java
@@ -1,6 +1,6 @@
 package com.canvas.google.gemini.service;
 
-public class GeminiPromptConsts {
+public class LLMPromptConsts {
     public static final String IMAGE_GENERATOR = """
             Choose only one of the most important scenes in the following content, and make a sentence that specifically describes the main scene suitable for the prompt in the image Generative AI. If the contents are inappropriate, print FORBIDDEN. Don't print the title, just print the contents of the prompt in English.
             
@@ -12,6 +12,6 @@ public class GeminiPromptConsts {
             """;
 
     public static final String KEYWORD_EXTRACT = """
-            일기에서 가장 핵심적인 키워드를 1~5개를 뽑아줘. 정확히 이 형식에 맞춰 뽑아줘 "keyword1, keyword2, keyword3, keyword4, keyword5"
+            "일기에서 가장 핵심적인 키워드를 1~5개를 뽑아줘. 키워드를 뽑을 때 보편적인 단어로만 뽑아줘 그리고 키워드를 뽑앨 때 글에 있는 내용으로만 뽑아줘. 딱히 적절한 키워드가 없으면 5개 미만으로 보내줘도 돼. 너가 반환하는 값을 무조건 이 형식에 맞춰서 반환해줘 '키워드1, 키워드2, 키워드3, 키워드4, 키워드5'"
             """;
 }

--- a/Infrastructure-Module/Google/src/main/resources/application.yml
+++ b/Infrastructure-Module/Google/src/main/resources/application.yml
@@ -1,2 +1,4 @@
 gemini:
   api-key: ${GEMINI_API_KEY}
+openai:
+  api-key: ${OPENAI_API_KEY}

--- a/Infrastructure-Module/ImageGenerator/src/main/java/com/canvas/generator/flux/exception/FluxException.java
+++ b/Infrastructure-Module/ImageGenerator/src/main/java/com/canvas/generator/flux/exception/FluxException.java
@@ -1,0 +1,49 @@
+package com.canvas.generator.flux.exception;
+
+import com.canvas.common.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class FluxException extends BusinessException {
+
+    private static final String CODE_PREFIX = "FLUX";
+    private static final String DEFAULT_MESSAGE = "Flux 예외가 발생했습니다.";
+    private static final HttpStatus DEFAULT_HTTP_STATUS = HttpStatus.BAD_REQUEST;
+
+    public FluxException() {
+        super(CODE_PREFIX, 0, DEFAULT_HTTP_STATUS, DEFAULT_MESSAGE);
+    }
+
+    public FluxException(int errorCode, HttpStatus httpStatus, String message) {
+        super(CODE_PREFIX, errorCode, httpStatus, message);
+    }
+
+    public static class FluxPendingException extends FluxException {
+        public FluxPendingException() {
+            super(1, HttpStatus.BAD_REQUEST, "보류 중입니다.");
+        }
+    }
+
+    public static class FluxTaskNotFoundException extends FluxException {
+        public FluxTaskNotFoundException() {
+            super(2, HttpStatus.NOT_FOUND, "작업을 찾을 수 없습니다.");
+        }
+    }
+
+    public static class FluxRequestModeratedException extends FluxException {
+        public FluxRequestModeratedException() {
+            super(3, HttpStatus.BAD_REQUEST, "요청이 검열되었습니다.");
+        }
+    }
+
+    public static class FluxContentModeratedException extends FluxException {
+        public FluxContentModeratedException() {
+            super(4, HttpStatus.BAD_REQUEST, "생성된 콘텐츠가 검열되었습니다.");
+        }
+    }
+
+    public static class FluxErrorException extends FluxException {
+        public FluxErrorException() {
+            super(5, HttpStatus.BAD_REQUEST, "알 수 없는 예외가 발생했습니다.");
+        }
+    }
+}

--- a/Infrastructure-Module/ImageGenerator/src/main/java/com/canvas/generator/flux/exception/FluxResultStatus.java
+++ b/Infrastructure-Module/ImageGenerator/src/main/java/com/canvas/generator/flux/exception/FluxResultStatus.java
@@ -1,0 +1,55 @@
+package com.canvas.generator.flux.exception;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum FluxResultStatus {
+    TASK_NOT_FOUND("Task not found") {
+        @Override
+        public void validate() {
+            throw new FluxException.FluxTaskNotFoundException();
+        }
+    },
+    PENDING("Pending") {
+        @Override
+        public void validate() {
+            throw new FluxException.FluxPendingException();
+        }
+    },
+    REQUEST_MODERATED("Request Moderated") {
+        @Override
+        public void validate() {
+            throw new FluxException.FluxRequestModeratedException();
+        }
+    },
+    CONTENT_MODERATED("Content Moderated") {
+        @Override
+        public void validate() {
+            throw new FluxException.FluxContentModeratedException();
+        }
+    },
+    READY("Ready") {
+        @Override
+        public void validate() {
+
+        }
+    },
+    ERROR("Error") {
+        @Override
+        public void validate() {
+            throw new FluxException.FluxErrorException();
+        }
+    };
+
+    private final String value;
+    public abstract void validate();
+
+    public static FluxResultStatus parse(String value) {
+        for (FluxResultStatus status : values()) {
+            if (status.value.equals(value)) {
+                return status;
+            }
+        }
+        throw new IllegalArgumentException("Unknown status: " + value);
+    }
+}

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/adapter/DiaryManagementJpaAdapter.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/adapter/DiaryManagementJpaAdapter.java
@@ -144,6 +144,14 @@ public class DiaryManagementJpaAdapter implements DiaryManagementPort {
     }
 
     @Override
+    public List<DiaryComplete> getByWriteIdAndKeywords(DomainId userId, List<String> keywords) {
+        List<DiaryEntity> diaryEntities = diaryJpaRepository.findByWriterIdAndKeywords(userId.value(), keywords);
+        return diaryEntities.stream()
+                .map(DiaryMapper::toCompleteDomain)
+                .toList();
+    }
+
+    @Override
     public void deleteById(DomainId diaryId) {
         diaryJpaRepository.deleteById(diaryId.value());
     }

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/adapter/DiaryManagementJpaAdapter.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/adapter/DiaryManagementJpaAdapter.java
@@ -116,21 +116,21 @@ public class DiaryManagementJpaAdapter implements DiaryManagementPort {
     }
 
     @Override
-    public Slice<DiaryOverview> getExploreByLatest(PageRequest pageRequest) {
+    public Slice<DiaryComplete> getExploreByLatest(PageRequest pageRequest) {
         var diaryEntities = diaryJpaRepository.findAllByIsPublicTrue(
                 PageMapper.toJpaPageRequest(pageRequest)
         );
 
-        return PageMapper.toDomainSlice(diaryEntities, DiaryMapper::toOverviewDomain);
+        return PageMapper.toDomainSlice(diaryEntities, DiaryMapper::toCompleteDomain);
     }
 
     @Override
-    public Slice<DiaryOverview> getExploreByLike(PageRequest pageRequest) {
+    public Slice<DiaryComplete> getExploreByLike(PageRequest pageRequest) {
         var diaryEntities = diaryJpaRepository.findAllByIsPublicTrueOrderByLikeCountDesc(
                 PageMapper.toJpaPageRequest(pageRequest)
         );
 
-        return PageMapper.toDomainSlice(diaryEntities, DiaryMapper::toOverviewDomain);
+        return PageMapper.toDomainSlice(diaryEntities, DiaryMapper::toCompleteDomain);
     }
 
     @Override

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/adapter/DiaryManagementJpaAdapter.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/adapter/DiaryManagementJpaAdapter.java
@@ -144,7 +144,7 @@ public class DiaryManagementJpaAdapter implements DiaryManagementPort {
     }
 
     @Override
-    public List<DiaryComplete> getByWriteIdAndKeywords(DomainId userId, List<String> keywords) {
+    public List<DiaryComplete> getByWriterIdAndKeywords(DomainId userId, List<String> keywords) {
         List<DiaryEntity> diaryEntities = diaryJpaRepository.findByWriterIdAndKeywords(userId.value(), keywords);
         return diaryEntities.stream()
                 .map(DiaryMapper::toCompleteDomain)

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/adapter/DiaryManagementJpaAdapter.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/adapter/DiaryManagementJpaAdapter.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Repository;
 import java.time.LocalDate;
 import java.time.temporal.TemporalAdjusters;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -144,11 +145,21 @@ public class DiaryManagementJpaAdapter implements DiaryManagementPort {
     }
 
     @Override
-    public List<DiaryComplete> getByWriterIdAndKeywords(DomainId userId, List<String> keywords) {
-        List<DiaryEntity> diaryEntities = diaryJpaRepository.findByWriterIdAndKeywords(userId.value(), keywords);
+    public List<DiaryComplete> getByWriterIdAndKeywords(DomainId userId, List<String> keywords, LocalDate baseDate) {
+        List<DiaryEntity> diaryEntities = diaryJpaRepository.findDiariesByWriterIdAndKeywordsBeforeBaseDate(
+                userId.value(),
+                keywords,
+                baseDate
+        );
         return diaryEntities.stream()
                 .map(DiaryMapper::toCompleteDomain)
                 .toList();
+    }
+
+    @Override
+    public Optional<DiaryComplete> getByWriterIdAndDate(DomainId userId, LocalDate beforeYear, LocalDate beforeMonth) {
+        return diaryJpaRepository.findByWriterIdAndDate(userId.value(), beforeYear, beforeMonth)
+                .map(DiaryMapper::toCompleteDomain);
     }
 
     @Override

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/adapter/LikeManagementJpaAdapter.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/adapter/LikeManagementJpaAdapter.java
@@ -1,7 +1,7 @@
 package com.canvas.persistence.jpa.diary.adapter;
 
 import com.canvas.application.like.exception.LikeException;
-import com.canvas.application.like.out.LikeManagementPort;
+import com.canvas.application.like.port.out.LikeManagementPort;
 import com.canvas.domain.common.DomainId;
 import com.canvas.domain.diary.entity.Like;
 import com.canvas.persistence.jpa.diary.LikeMapper;

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/entity/DiaryEntity.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/entity/DiaryEntity.java
@@ -38,6 +38,9 @@ public class DiaryEntity extends BaseEntity {
     private List<ImageEntity> imageEntities = new ArrayList<>();
     @OneToMany(mappedBy = "diaryEntity", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<LikeEntity> likeEntities = new ArrayList<>();
+    @OneToMany(mappedBy = "diaryEntity", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<DiaryKeywordEntity> diaryKeywordEntities = new ArrayList<>();
+
 
     public DiaryEntity(UUID id, String content, String emotion, Boolean isPublic, LocalDate date, UUID writerId) {
         this.id = id;

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/entity/DiaryKeywordEntity.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/entity/DiaryKeywordEntity.java
@@ -25,11 +25,11 @@ public class DiaryKeywordEntity extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "keyword_id", insertable = false, updatable = false)
-    private KeywordEntity keyword;
+    private KeywordEntity keywordEntity;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "diary_id", insertable = false, updatable = false)
-    private DiaryEntity diary;
+    private DiaryEntity diaryEntity;
 
 
 }

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/entity/DiaryKeywordEntity.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/entity/DiaryKeywordEntity.java
@@ -1,0 +1,35 @@
+package com.canvas.persistence.jpa.diary.entity;
+
+import com.canvas.persistence.jpa.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "diary_keyword")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class DiaryKeywordEntity extends BaseEntity {
+
+    @Id
+    private UUID id;
+
+    @Column(name = "diary_id", nullable = false)
+    private UUID diaryId;
+
+    @Column(name = "keyword_id", nullable = false)
+    private UUID keywordId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "keyword_id", insertable = false, updatable = false)
+    private KeywordEntity keyword;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "diary_id", insertable = false, updatable = false)
+    private DiaryEntity diary;
+
+
+}

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/entity/KeywordEntity.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/entity/KeywordEntity.java
@@ -1,0 +1,26 @@
+package com.canvas.persistence.jpa.diary.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "keyword")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class KeywordEntity {
+
+    @Id
+    private UUID id;
+
+    private String name;
+
+    @OneToMany(mappedBy = "keywordEntity", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<DiaryKeywordEntity> diaryKeywordEntities = new ArrayList<>();
+
+}

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/repository/DiaryJpaRepository.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/repository/DiaryJpaRepository.java
@@ -62,9 +62,9 @@ public interface DiaryJpaRepository extends JpaRepository<DiaryEntity, UUID> {
         select d
         from DiaryEntity d
         where d.writerId = :writerId and d.id in (
-            select dk.diary.id
+            select dk.diaryEntity.id
             from DiaryKeywordEntity dk
-            join dk.keyword k
+            join dk.keywordEntity k
             where k.name in :keywords
         )
     """)

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/repository/DiaryJpaRepository.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/repository/DiaryJpaRepository.java
@@ -58,15 +58,29 @@ public interface DiaryJpaRepository extends JpaRepository<DiaryEntity, UUID> {
 
     boolean existsByIdAndWriterId(UUID diaryId, UUID writerId);
 
+
     @Query("""
         select d
         from DiaryEntity d
-        where d.writerId = :writerId and d.id in (
+        where d.id = :diaryId and (d.date = :beforeYear or d.date = :beforeMonth)
+        order by
+          case
+            when d.date = :beforeMonth then 0
+            when d.date = :beforeYear then 1
+            else 2
+          end
+    """)
+    Optional<DiaryEntity> findByWriterIdAndDate(UUID writerId, LocalDate beforeYear, LocalDate beforeMonth);
+
+    @Query("""
+        select d
+        from DiaryEntity d
+        where d.writerId = :writerId and d.date < :baseDate and d.id in (
             select dk.diaryEntity.id
             from DiaryKeywordEntity dk
             join dk.keywordEntity k
             where k.name in :keywords
         )
     """)
-    List<DiaryEntity> findByWriterIdAndKeywords(UUID writerId, List<String> keywords);
+    List<DiaryEntity> findDiariesByWriterIdAndKeywordsBeforeBaseDate(UUID writerId, List<String> keywords, LocalDate baseDate);
 }

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/repository/DiaryJpaRepository.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/repository/DiaryJpaRepository.java
@@ -57,4 +57,16 @@ public interface DiaryJpaRepository extends JpaRepository<DiaryEntity, UUID> {
     Slice<DiaryEntity> findByUserLiked(Pageable pageable, UUID userId);
 
     boolean existsByIdAndWriterId(UUID diaryId, UUID writerId);
+
+    @Query("""
+        select d
+        from DiaryEntity d
+        where d.writerId = :writerId and d.id in (
+            select dk.diary.id
+            from DiaryKeywordEntity dk
+            join dk.keyword k
+            where k.name in :keywords
+        )
+    """)
+    List<DiaryEntity> findByWriterIdAndKeywords(UUID writerId, List<String> keywords);
 }

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/user/UserMapper.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/user/UserMapper.java
@@ -10,7 +10,7 @@ import com.canvas.persistence.jpa.user.entity.UserTokenEntity;
 public class UserMapper {
     public static UserEntity toEntity(User user) {
         return new UserEntity(
-                user.getDomainId().value(),
+                user.getId().value(),
                 user.getUsername(),
                 user.getSocialId(),
                 user.getSocialLoginProvider().name()
@@ -26,7 +26,7 @@ public class UserMapper {
     }
 
     public static User toDomain(UserEntity userEntity) {
-        return new User(
+        return User.create(
                 new DomainId(userEntity.getId()),
                 userEntity.getUsername(),
                 userEntity.getSocialId(),
@@ -35,7 +35,7 @@ public class UserMapper {
     }
 
     public static UserToken toDomain(UserTokenEntity userTokenEntity) {
-        return new UserToken(
+        return UserToken.create(
                 new DomainId(userTokenEntity.getId()),
                 userTokenEntity.getToken(),
                 new DomainId(userTokenEntity.getUserId())

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/user/adapter/UserManagementJpaAdapter.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/user/adapter/UserManagementJpaAdapter.java
@@ -31,7 +31,7 @@ public class UserManagementJpaAdapter implements UserManagementPort {
 
     @Override
     public void delete(User user) {
-        userJpaRepository.deleteById(user.getDomainId().value());
+        userJpaRepository.deleteById(user.getId().value());
     }
 
     @Override

--- a/Infrastructure-Module/Persistence/src/testFixtures/java/com/canvas/persistence/jpa/builder/UserEntityBuilder.java
+++ b/Infrastructure-Module/Persistence/src/testFixtures/java/com/canvas/persistence/jpa/builder/UserEntityBuilder.java
@@ -7,7 +7,7 @@ import java.util.UUID;
 public class UserEntityBuilder {
 
     private UUID id;
-    private String email;
+    private String socialId;
     private String username;
     private String socialLoginProvider;
 
@@ -16,8 +16,8 @@ public class UserEntityBuilder {
         return this;
     }
 
-    public UserEntityBuilder email(String email) {
-        this.email = email;
+    public UserEntityBuilder socialId(String socialId) {
+        this.socialId = socialId;
         return this;
     }
 
@@ -34,7 +34,7 @@ public class UserEntityBuilder {
     public UserEntity build() {
         return new UserEntity(
                 this.id,
-                this.email,
+                this.socialId,
                 this.username,
                 this.socialLoginProvider
         );

--- a/Infrastructure-Module/Persistence/src/testFixtures/java/com/canvas/persistence/jpa/fixture/DiaryEntityFixture.java
+++ b/Infrastructure-Module/Persistence/src/testFixtures/java/com/canvas/persistence/jpa/fixture/DiaryEntityFixture.java
@@ -14,7 +14,7 @@ import static com.canvas.persistence.jpa.fixture.UserEntityFixture.*;
 public enum DiaryEntityFixture {
     PUBLIC_MY_DIARY(
             "내용1",
-            "감정1",
+            "JOY",
             true,
             LocalDate.of(2024, 10, 15),
             MYSELF
@@ -22,7 +22,7 @@ public enum DiaryEntityFixture {
 
     PUBLIC_OTHER_DIARY(
             "내용2",
-            "감정2",
+            "ANGER",
             true,
             LocalDate.of(2024, 10, 17),
             OTHER1
@@ -30,7 +30,7 @@ public enum DiaryEntityFixture {
 
     PRIVATE_OTHER_DIARY(
             "내용3",
-            "감정3",
+            "SADNESS",
             false,
             LocalDate.of(2024, 10, 31),
             OTHER2

--- a/Infrastructure-Module/Persistence/src/testFixtures/java/com/canvas/persistence/jpa/fixture/UserEntityFixture.java
+++ b/Infrastructure-Module/Persistence/src/testFixtures/java/com/canvas/persistence/jpa/fixture/UserEntityFixture.java
@@ -9,19 +9,19 @@ import java.util.UUID;
 
 public enum UserEntityFixture {
 
-    MYSELF("myEmail", "myUsername", "KAKAO"),
-    OTHER1("email1", "username1", "KAKAO"),
-    OTHER2("email2", "username2", "KAKAO");
+    MYSELF("mySocialId", "myUsername", "KAKAO"),
+    OTHER1("socialId1", "username1", "KAKAO"),
+    OTHER2("socialId2", "username2", "KAKAO");
 
     @Getter
     private final UUID id;
-    private final String email;
+    private final String socialId;
     private final String username;
     private final String socialLoginProvider;
 
-    UserEntityFixture(String email, String username, String socialLoginProvider) {
+    UserEntityFixture(String socialId, String username, String socialLoginProvider) {
         this.id = DomainId.generate().value();
-        this.email = email;
+        this.socialId = socialId;
         this.username = username;
         this.socialLoginProvider = socialLoginProvider;
     }
@@ -29,7 +29,7 @@ public enum UserEntityFixture {
     public UserEntity getUserEntity() {
         return new UserEntityBuilder()
                 .id(id)
-                .email(email)
+                .socialId(socialId)
                 .username(username)
                 .socialLoginProvider(socialLoginProvider)
                 .build();


### PR DESCRIPTION
## 주요 작업

#106 

- [x] gpt api 수정
- [x] gemini, gpt LLM 서비스로 추상화
- [x] 회고 조회 로직 구현 

## 고민 사항
### gemini api 오류
gemini api가 생각보다 많은 오류를 던져서 gpt api를 추가로 구현하였다. 이후 geminiService를 LLMService로 변경 후에 geminiService와 gptService가 LLMService의 인터페이스를 implement 하게 하였다.

### 과거 일기 조회 로직
과거 회고에 대한 일기를 가져오는 기준이 명확하지 않아 기준을 명확하게 하였다.
우선순위는 
1. 1년 전 일기, 키워드 상관x
2. 1달 전 일기, 키워드 상관x
3. 키워드와 연관 있는 모든 일기를 가져온 후 랜덤(findany)를 이용하여 일기 선택
4. 3번까지 존재하지 않으면 회고 일기를 전달하지 않음

