### PR TITLE
feat: gpt로 LLM 사용하도록 구현

### DIFF
--- a/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/DiaryContentConvertGeminiAdapter.java
+++ b/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/DiaryContentConvertGeminiAdapter.java
@@ -4,8 +4,8 @@ import com.canvas.application.diary.port.out.DiaryEmotionExtractPort;
 import com.canvas.application.diary.port.out.DiaryKeywordExtractPort;
 import com.canvas.application.image.port.out.ImagePromptGeneratePort;
 import com.canvas.domain.diary.enums.Emotion;
-import com.canvas.google.gemini.service.GeminiPromptConsts;
-import com.canvas.google.gemini.service.GeminiService;
+import com.canvas.google.gemini.service.LLMPromptConsts;
+import com.canvas.google.gemini.service.LLMService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -19,22 +19,22 @@ import java.util.List;
 public class DiaryContentConvertGeminiAdapter
         implements DiaryEmotionExtractPort, ImagePromptGeneratePort, DiaryKeywordExtractPort {
 
-    private final GeminiService geminiService;
+    private final LLMService llmService;
 
     @Override
     public Emotion emotionExtract(String content) {
-        String emotion = geminiService.generate(GeminiPromptConsts.EMOTION_EXTRACT + content);
+        String emotion = llmService.generate(LLMPromptConsts.EMOTION_EXTRACT + content);
         return Emotion.parse(emotion);
     }
 
     @Override
     public String generatePrompt(String content) {
-        return geminiService.generate(GeminiPromptConsts.IMAGE_GENERATOR + content);
+        return llmService.generate(LLMPromptConsts.IMAGE_GENERATOR + content);
     }
 
     @Override
     public List<String> keywordExtract(String content) {
-        String response = geminiService.generate(GeminiPromptConsts.KEYWORD_EXTRACT + content);
+        String response = llmService.generate(LLMPromptConsts.KEYWORD_EXTRACT + content);
         return Arrays.stream(response.split(", ")).toList();
     }
 }

--- a/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/exception/GptException.java
+++ b/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/exception/GptException.java
@@ -1,0 +1,32 @@
+package com.canvas.google.gemini.exception;
+
+import com.canvas.common.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class GptException extends BusinessException {
+
+  private static final String CODE_PREFIX = "GPT";
+  private static final String DEFAULT_MESSAGE = "GPT 예외가 발생했습니다.";
+  private static final HttpStatus DEFAULT_HTTP_STATUS = HttpStatus.BAD_REQUEST;
+
+  public GptException() {
+    super(CODE_PREFIX, 0, DEFAULT_HTTP_STATUS, DEFAULT_MESSAGE);
+  }
+
+  public GptException(int errorCode, HttpStatus httpStatus, String message) {
+    super(CODE_PREFIX, errorCode, httpStatus, message);
+  }
+
+  public static class GptSafetyException extends GptException {
+    public GptSafetyException() {
+      super(1, HttpStatus.BAD_REQUEST, "유해한 내용입니다.");
+    }
+  }
+
+  public static class GptTooManyRequestsException extends GptException {
+    public GptTooManyRequestsException() {
+      super(2, HttpStatus.TOO_MANY_REQUESTS, "요청이 너무 많습니다.");
+    }
+  }
+
+}

--- a/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/service/GeminiService.java
+++ b/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/service/GeminiService.java
@@ -16,7 +16,7 @@ import java.util.Objects;
 
 @Component
 @Slf4j
-public class GeminiService {
+public class GeminiService implements LLMService{
 
     @Value("${gemini.api-key}")
     private String API_KEY;
@@ -36,7 +36,7 @@ public class GeminiService {
                         })
                         .bodyToMono(Response.class)
                         .retryWhen(
-                                 Retry.fixedDelay(3, Duration.ofSeconds(3))
+                                Retry.fixedDelay(3, Duration.ofSeconds(3))
                                         .filter(throwable -> throwable instanceof GeminiException.GeminiTooManyRequestsException))
                         .doOnError(error -> new GeminiException.GeminiTooManyRequestsException())
                         .map(response -> {
@@ -48,6 +48,8 @@ public class GeminiService {
                         .block())
                 .getText();
     }
+
+
 
     public record Request(
             List<Content> contents

--- a/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/service/GptService.java
+++ b/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/service/GptService.java
@@ -1,0 +1,100 @@
+package com.canvas.google.gemini.service;
+
+import com.canvas.google.gemini.exception.GptException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.util.retry.Retry;
+
+import java.time.Duration;
+import java.util.List;
+
+@Primary
+@Component
+@Slf4j
+public class GptService implements LLMService{
+
+    @Value("${openai.api-key}")
+    private String apiKey;
+
+    private final WebClient webClient = WebClient.create("https://api.openai.com/v1/chat/completions");
+
+    public String generate(String prompt) {
+        Response response = webClient.post()
+                .uri("")
+                .header("Authorization", "Bearer " + apiKey)
+                .header("Accept", "application/json")
+                .bodyValue(Request.of(prompt))
+                .retrieve()
+                .bodyToMono(Response.class)
+                .doOnNext(res -> {
+                    log.info(res.getReason());
+                    if (res.getReason().equals("null")) {
+                        throw new NullPointerException("응답 오류");
+                    }
+                    else if (!res.getReason().equals("stop")) {
+                        throw new GptException();
+                    }
+                })
+                .retryWhen(
+                        Retry.fixedDelay(3, Duration.ofSeconds(3))
+                                .filter(throwable -> throwable instanceof NullPointerException)
+                )
+                .doOnError(error -> {
+                    if (error instanceof NullPointerException) {
+                        throw new GptException.GptTooManyRequestsException();
+                    }
+                    throw new GptException();
+                })
+                .block();
+        log.info("{}", response.usage().total_tokens());
+        return response.getContent();
+    }
+
+    public record Request(
+            String model,
+            List<Message> messages,
+            Double temperature,
+            Integer max_tokens
+    ) {
+        public static Request of(String prompt) {
+            return new Request(
+                    "gpt-4o-mini",
+                    List.of(
+                            new Message("user", prompt)
+                    ),
+                    0.7,
+                    300
+            );
+        }
+
+        public record Message(String role, String content) {}
+    }
+
+    public record Response(
+            List<Choice> choices,
+            Usage usage
+    ) {
+
+        public String getContent() {
+            return choices.get(0).message().content().trim();
+        }
+        public String getReason() {
+            return choices.get(0).finish_reason();
+        }
+
+        public record Choice(
+                Message message,
+                String finish_reason            //  stop: 정상, length: 토큰 초과, content_filter: 부적절, null: 모델 오류
+        ) {
+            public record Message(
+                    String content
+            ) {}
+        }
+        public record Usage(
+                Integer total_tokens
+        ) {}
+    }
+}

--- a/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/service/LLMPromptConsts.java
+++ b/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/service/LLMPromptConsts.java
@@ -1,6 +1,6 @@
 package com.canvas.google.gemini.service;
 
-public class GeminiPromptConsts {
+public class LLMPromptConsts {
     public static final String IMAGE_GENERATOR = """
             Choose only one of the most important scenes in the following content, and make a sentence that specifically describes the main scene suitable for the prompt in the image Generative AI. If the contents are inappropriate, print FORBIDDEN. Don't print the title, just print the contents of the prompt in English.
             
@@ -12,6 +12,6 @@ public class GeminiPromptConsts {
             """;
 
     public static final String KEYWORD_EXTRACT = """
-            일기에서 가장 핵심적인 키워드를 1~5개를 뽑아줘. 정확히 이 형식에 맞춰 뽑아줘 "keyword1, keyword2, keyword3, keyword4, keyword5"
+            "일기에서 가장 핵심적인 키워드를 1~5개를 뽑아줘. 키워드를 뽑을 때 보편적인 단어로만 뽑아줘 그리고 키워드를 뽑앨 때 글에 있는 내용으로만 뽑아줘. 딱히 적절한 키워드가 없으면 5개 미만으로 보내줘도 돼. 너가 반환하는 값을 무조건 이 형식에 맞춰서 반환해줘 '키워드1, 키워드2, 키워드3, 키워드4, 키워드5'"
             """;
 }

--- a/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/service/LLMService.java
+++ b/Infrastructure-Module/Google/src/main/java/com/canvas/google/gemini/service/LLMService.java
@@ -1,0 +1,5 @@
+package com.canvas.google.gemini.service;
+
+public interface LLMService {
+    String generate(String prompt);
+}

--- a/Infrastructure-Module/Google/src/main/resources/application.yml
+++ b/Infrastructure-Module/Google/src/main/resources/application.yml
@@ -1,2 +1,4 @@
 gemini:
   api-key: ${GEMINI_API_KEY}
+openai:
+  api-key: ${OPENAI_API_KEY}

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/repository/DiaryJpaRepository.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/repository/DiaryJpaRepository.java
@@ -63,12 +63,7 @@ public interface DiaryJpaRepository extends JpaRepository<DiaryEntity, UUID> {
         select d
         from DiaryEntity d
         where d.writerId = :writerId and (d.date = :beforeYear or d.date = :beforeMonth)
-        order by
-          case
-            when d.date = :beforeMonth then 0
-            when d.date = :beforeYear then 1
-            else 2
-          end
+        order by d.date asc
     """)
     Optional<DiaryEntity> findByWriterIdAndDate(UUID writerId, LocalDate beforeYear, LocalDate beforeMonth);
 


### PR DESCRIPTION
## 주요 작업

#106 

- [x] gpt api 수정
- [x] gemini, gpt LLM 서비스로 추상화
- [x] 회고 조회 로직 구현 

## 고민 사항
### gemini api 오류
gemini api가 생각보다 많은 오류를 던져서 gpt api를 추가로 구현하였다. 이후 geminiService를 LLMService로 변경 후에 geminiService와 gptService가 LLMService의 인터페이스를 implement 하게 하였다.

### 과거 일기 조회 로직
과거 회고에 대한 일기를 가져오는 기준이 명확하지 않아 기준을 명확하게 하였다.
우선순위는 
1. 1년 전 일기, 키워드 상관x
2. 1달 전 일기, 키워드 상관x
3. 키워드와 연관 있는 모든 일기를 가져온 후 랜덤(findany)를 이용하여 일기 선택
4. 3번까지 존재하지 않으면 회고 일기를 전달하지 않음

