### PR TITLE
feat: 감정 통계 기능 추가

### DIFF
--- a/Application-Module/src/main/java/com/canvas/application/common/enums/Style.java
+++ b/Application-Module/src/main/java/com/canvas/application/common/enums/Style.java
@@ -13,7 +13,7 @@ public enum Style {
     OILPAINTING("oil painting", "유화", "https://canvas-diary.s3.ap-northeast-2.amazonaws.com/%ED%99%94%ED%92%8D/%E1%84%8B%E1%85%B2%E1%84%92%E1%85%AA.webp"),
     WATERCOLOR("watercolor", "수채화", "https://canvas-diary.s3.ap-northeast-2.amazonaws.com/%ED%99%94%ED%92%8D/%E1%84%89%E1%85%AE%E1%84%8E%E1%85%A2%E1%84%92%E1%85%AA.webp"),
     ANIMATION("3D animation", "3D 그래픽", "https://canvas-diary.s3.ap-northeast-2.amazonaws.com/%ED%99%94%ED%92%8D/%E1%84%8B%E1%85%A2%E1%84%82%E1%85%B5%E1%84%86%E1%85%A6%E1%84%8B%E1%85%B5%E1%84%89%E1%85%A7%E1%86%AB+.webp"),
-    PIXELART("retro graphics", "픽셀 아트", "https://canvas-diary.s3.ap-northeast-2.amazonaws.com/%ED%99%94%ED%92%8D/%E1%84%91%E1%85%B5%E1%86%A8%E1%84%89%E1%85%A6%E1%86%AF+%E1%84%8B%E1%85%A1%E1%84%90%E1%85%B3.webp"),
+    PIXELART("8-bit graphics", "픽셀 아트", "https://canvas-diary.s3.ap-northeast-2.amazonaws.com/%ED%99%94%ED%92%8D/%E1%84%91%E1%85%B5%E1%86%A8%E1%84%89%E1%85%A6%E1%86%AF+%E1%84%8B%E1%85%A1%E1%84%90%E1%85%B3.webp"),
     COMICS("American comics style", "코믹스", "https://canvas-diary.s3.ap-northeast-2.amazonaws.com/%ED%99%94%ED%92%8D/%E1%84%8F%E1%85%A9%E1%84%86%E1%85%B5%E1%86%A8%E1%84%89%E1%85%B3.jpeg"),
     ABSTRACT("abstract", "추상화", "https://canvas-diary.s3.ap-northeast-2.amazonaws.com/%ED%99%94%ED%92%8D/%E1%84%8E%E1%85%AE%E1%84%89%E1%85%A1%E1%86%BC%E1%84%92%E1%85%AA.jpeg"),
     ANIME("anime", "애니메이션", "https://canvas-diary.s3.ap-northeast-2.amazonaws.com/%ED%99%94%ED%92%8D/%E1%84%8B%E1%85%A2%E1%84%82%E1%85%B5%E1%84%86%E1%85%A6%E1%84%8B%E1%85%B5%E1%84%89%E1%85%A7%E1%86%AB.jpeg");

--- a/Application-Module/src/main/java/com/canvas/application/diary/port/in/GetEmotionStatsUseCase.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/port/in/GetEmotionStatsUseCase.java
@@ -1,0 +1,43 @@
+package com.canvas.application.diary.port.in;
+
+import com.canvas.domain.diary.enums.Emotion;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface GetEmotionStatsUseCase {
+    Response getWeekEmotionStats(Query.Week query);
+    Response getMonthEmotionStats(Query.Month query);
+
+    class Query {
+        public record Week(
+                String userId,
+                LocalDate date
+        ) {}
+
+        public record Month(
+                String userId,
+                LocalDate date
+        ) {}
+    }
+
+    record Response(
+            List<BarData> barData,
+            List<PieData> pieData
+    ) {
+        public record BarData(
+                Long dataKey,
+                Long positive,
+                Long neutral,
+                Long negative
+        ) {
+        }
+
+        public record PieData(
+                Emotion emotion,
+                Long diaryCount
+        ) {
+        }
+    }
+
+}

--- a/Application-Module/src/main/java/com/canvas/application/diary/port/out/DiaryManagementPort.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/port/out/DiaryManagementPort.java
@@ -18,7 +18,7 @@ public interface DiaryManagementPort {
     DiaryComplete getById(DomainId diaryId);
     DiaryComplete getByIdAndWriterId(DomainId diaryId, DomainId writerId);
     boolean existsByIdAndWriterId(DomainId diaryId, DomainId writerId);
-    List<DiaryBasic> getByUserIdAndMonth(DomainId userId, LocalDate date);
+    List<DiaryBasic> getByWriterIdAndDateBetween(DomainId userId, LocalDate start, LocalDate end);
     Slice<DiaryOverview> getAlbum(PageRequest pageRequest, DomainId userId);
     Slice<DiaryOverview> getAlbumByContent(PageRequest pageRequest, DomainId userId, String content);
     Slice<DiaryOverview> getAlbumByEmotion(PageRequest pageRequest, DomainId userId, Emotion emotion);

--- a/Application-Module/src/main/java/com/canvas/application/diary/service/DiaryQueryService.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/service/DiaryQueryService.java
@@ -20,8 +20,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.util.List;
-import java.util.Optional;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAdjusters;
+import java.util.*;
 
 @Service
 @Transactional(readOnly = true)
@@ -63,9 +64,13 @@ public class DiaryQueryService
 
     @Override
     public GetDiaryUseCase.Response.HomeCalendar getHomeCalendar(GetDiaryUseCase.Query.HomeCalendar query) {
-        List<DiaryBasic> diaries = diaryManagementPort.getByUserIdAndMonth(
+        LocalDate startDate = query.date().with(TemporalAdjusters.firstDayOfMonth());
+        LocalDate endDate = query.date().with(TemporalAdjusters.lastDayOfMonth());
+
+        List<DiaryBasic> diaries = diaryManagementPort.getByWriterIdAndDateBetween(
                 DomainId.from(query.userId()),
-                query.date()
+                startDate,
+                endDate
         );
 
         return new GetDiaryUseCase.Response.HomeCalendar(

--- a/Application-Module/src/test/java/com/canvas/application/diary/service/DiaryQueryServiceTest.java
+++ b/Application-Module/src/test/java/com/canvas/application/diary/service/DiaryQueryServiceTest.java
@@ -15,6 +15,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 
 import static com.canvas.application.diary.DiaryApplicationFixture.getGetDiaryQuery;
@@ -88,10 +89,13 @@ class DiaryQueryServiceTest {
         // given
         User user = MYSELF.getUser();
         LocalDate date = LocalDate.now();
+        LocalDate startDate = LocalDate.now().with(TemporalAdjusters.firstDayOfMonth());
+        LocalDate endDate = LocalDate.now().with(TemporalAdjusters.lastDayOfMonth());
+
         GetDiaryUseCase.Query.HomeCalendar query = getHomeCalendarQuery(user, date);
         List<DiaryBasic> diaries = DiaryFixture.getAllDiaryBasicByUser(MYSELF);
 
-        given(diaryManagementPort.getByUserIdAndMonth(user.getId(), date))
+        given(diaryManagementPort.getByWriterIdAndDateBetween(user.getId(), startDate, endDate))
                 .willReturn(diaries);
 
         // when

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/stats/api/StatsApi.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/stats/api/StatsApi.java
@@ -1,0 +1,38 @@
+package com.canvas.bootstrap.stats.api;
+
+import com.canvas.bootstrap.common.annotation.AccessUser;
+import com.canvas.bootstrap.stats.dto.EmotionStatsResponse;
+import com.canvas.bootstrap.stats.type.StatsType;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.time.LocalDate;
+
+@Tag(name = "Stats", description = "Statistics API")
+@RequestMapping("/api/v1/stats")
+public interface StatsApi {
+    @Operation(summary = "감정 통계 조회")
+    @GetMapping("/emotions")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "감정 통계 조회 성공"
+            )
+    })
+    EmotionStatsResponse getEmotionStats(@AccessUser String userId, @RequestParam StatsType type, @RequestParam LocalDate date);
+
+/*    @Operation(summary = "키워드 통계 조회")
+    @GetMapping("/keywords")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "키워드 통계 조회 성공"
+            )
+    })
+    KeywordStatsResponse getKeywordStats(@RequestParam StatsType type);*/
+}

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/stats/controller/StatsController.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/stats/controller/StatsController.java
@@ -1,0 +1,46 @@
+package com.canvas.bootstrap.stats.controller;
+
+import com.canvas.application.diary.port.in.GetEmotionStatsUseCase;
+import com.canvas.bootstrap.stats.api.StatsApi;
+import com.canvas.bootstrap.stats.dto.EmotionStatsResponse;
+import com.canvas.bootstrap.stats.type.StatsType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+
+@RestController
+@RequiredArgsConstructor
+public class StatsController implements StatsApi {
+
+    private final GetEmotionStatsUseCase getEmotionStatsUseCase;
+
+    @Override
+    public EmotionStatsResponse getEmotionStats(String userId, StatsType type, LocalDate date) {
+        GetEmotionStatsUseCase.Response response = switch (type) {
+            case WEEK -> getEmotionStatsUseCase.getWeekEmotionStats(new GetEmotionStatsUseCase.Query.Week(userId, date));
+            case MONTH -> getEmotionStatsUseCase.getMonthEmotionStats(new GetEmotionStatsUseCase.Query.Month(userId, date));
+        };
+
+        return new EmotionStatsResponse(
+                response.barData().stream()
+                        .map(barData -> new EmotionStatsResponse.BarData(
+                                barData.dataKey(),
+                                barData.positive(),
+                                barData.neutral(),
+                                barData.negative()))
+                        .toList(),
+                response.pieData().stream()
+                        .map(pieData -> new EmotionStatsResponse.PieData(
+                                pieData.emotion(),
+                                pieData.diaryCount()))
+                        .toList()
+        );
+    }
+
+/*    @Override
+    public KeywordStatsResponse getKeywordStats(StatsType type) {
+        return null;
+    }*/
+
+}

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/stats/dto/EmotionStatsResponse.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/stats/dto/EmotionStatsResponse.java
@@ -1,0 +1,24 @@
+package com.canvas.bootstrap.stats.dto;
+
+import com.canvas.domain.diary.enums.Emotion;
+
+import java.util.List;
+
+public record EmotionStatsResponse(
+        List<BarData> barData,
+        List<PieData> pieData
+) {
+    public record BarData(
+            Long dataKey,
+            Long positive,
+            Long neutral,
+            Long negative
+    ) {
+    }
+
+    public record PieData(
+            Emotion emotion,
+            Long diaryCount
+    ) {
+    }
+}

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/stats/type/StatsType.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/stats/type/StatsType.java
@@ -1,0 +1,5 @@
+package com.canvas.bootstrap.stats.type;
+
+public enum StatsType {
+    WEEK, MONTH
+}

--- a/Domain-Module/src/main/java/com/canvas/domain/diary/enums/Emotion.java
+++ b/Domain-Module/src/main/java/com/canvas/domain/diary/enums/Emotion.java
@@ -6,20 +6,23 @@ import lombok.RequiredArgsConstructor;
 import java.util.Arrays;
 import java.util.List;
 
+import static com.canvas.domain.diary.enums.Sentiment.*;
+
 @RequiredArgsConstructor
 @Getter
 public enum Emotion {
-    ANGER("분노"),
-    SADNESS("슬픔"),
-    JOY("기쁨"),
-    FEAR("공포"),
-    DISGUST("혐오"),
-    SHAME("부끄러움"),
-    SURPRISE("놀라움"),
-    CURIOSITY("호기심"),
-    NONE("무분류");
+    ANGER("분노", NEGATIVE),
+    SADNESS("슬픔", NEGATIVE),
+    JOY("기쁨", POSITIVE),
+    FEAR("공포", NEGATIVE),
+    DISGUST("혐오", NEGATIVE),
+    SHAME("부끄러움", NEGATIVE),
+    SURPRISE("놀라움", NEUTRAL),
+    CURIOSITY("호기심", POSITIVE),
+    NONE("무분류", NEUTRAL);
 
     private final String koreanName;
+    private final Sentiment sentiment;
 
     public static Emotion parse(String value) {
         return Arrays.stream(Emotion.values())

--- a/Domain-Module/src/main/java/com/canvas/domain/diary/enums/Sentiment.java
+++ b/Domain-Module/src/main/java/com/canvas/domain/diary/enums/Sentiment.java
@@ -1,0 +1,7 @@
+package com.canvas.domain.diary.enums;
+
+public enum Sentiment {
+    POSITIVE,
+    NEGATIVE,
+    NEUTRAL
+}

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/adapter/DiaryManagementJpaAdapter.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/adapter/DiaryManagementJpaAdapter.java
@@ -17,7 +17,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
-import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 import java.util.Optional;
 
@@ -58,10 +57,7 @@ public class DiaryManagementJpaAdapter implements DiaryManagementPort {
     }
 
     @Override
-    public List<DiaryBasic> getByUserIdAndMonth(DomainId userId, LocalDate date) {
-        LocalDate start = date.with(TemporalAdjusters.firstDayOfMonth());
-        LocalDate end = date.with(TemporalAdjusters.lastDayOfMonth());
-
+    public List<DiaryBasic> getByWriterIdAndDateBetween(DomainId userId, LocalDate start, LocalDate end) {
         return diaryJpaRepository.findByWriterIdAndDateBetween(userId.value(), start, end).stream()
                                  .map(DiaryMapper::toBasicDomain)
                                  .toList();


### PR DESCRIPTION
# 이슈
- #103 

# 구현 내용
* [x] 감정 통계 조회 기능 추가
* [x] 날짜 기반 일기 조회 메소드 수정
* [x] 픽셀 아트 프롬프트 수정

# 세부 내용
## 감정 통계 조회 기능 추가
### Emotion
```java
ANGER("분노", NEGATIVE),
SADNESS("슬픔", NEGATIVE),
JOY("기쁨", POSITIVE),
FEAR("공포", NEGATIVE),
DISGUST("혐오", NEGATIVE),
SHAME("부끄러움", NEGATIVE),
SURPRISE("놀라움", NEUTRAL),
CURIOSITY("호기심", POSITIVE),
NONE("무분류", NEUTRAL);

private final String koreanName;
private final Sentiment sentiment;
```
- 감정에 대응하는 `Sentiment` 매핑

### DiaryQueryService
```java
@Override
public GetEmotionStatsUseCase.Response getWeekEmotionStats(GetEmotionStatsUseCase.Query.Week query) {
    LocalDate startDate = query.date().with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY)).minusWeeks(5);
    LocalDate endDate = query.date().with(TemporalAdjusters.nextOrSame(DayOfWeek.SATURDAY));
```
- `startDate`: 통계 조회 주에서 5주 전 일요일인 날
- `endDate`: 통계 조회 주에서 토요일인 날

```java
    List<DiaryBasic> diaries = diaryManagementPort.getByWriterIdAndDateBetween(
            DomainId.from(query.userId()),
            startDate,
            endDate
    );
```
- 자신의 5주 전부터 이번주까지의 일기 조회

```java
    Map<Long, Map<Sentiment, Long>> barData = diaries.stream()
            .collect(Collectors.groupingBy(
                    diary -> -(ChronoUnit.DAYS.between(diary.getDate(), endDate) / 7),
                    Collectors.groupingBy(
                            diary -> diary.getEmotion().getSentiment(),
                            Collectors.counting())
            ));
```
- 조회한 일기를 7일 단위로 그룹핑하고, `Sentiment`로 다시 그룹핑하여 막대 그래프 데이터 생성

```java
    Map<Emotion, Long> pieData = diaries.stream()
            .filter(diary -> diary.getDate().isAfter(endDate.minusWeeks(1)))
            .collect(Collectors.groupingBy(DiaryBasic::getEmotion, Collectors.counting()));

    return toEmotionStatsResponse(barData, pieData);
}
```
- 조회한 일기의 이번 주 데이터만 사용
- `Emotion`으로 그룹핑하여 원형 그래프 데이터 생성

```java
@Override
public GetEmotionStatsUseCase.Response getMonthEmotionStats(GetEmotionStatsUseCase.Query.Month query) {
    LocalDate startDate = query.date().with(TemporalAdjusters.firstDayOfMonth()).minusMonths(5);
    LocalDate endDate = query.date().with(TemporalAdjusters.lastDayOfMonth());
```
- `startDate`: 통계 조회 달에서 5달 전 첫날
- `endDate`: 통계 조회 달에서 마지막 날

```java
    List<DiaryBasic> diaries = diaryManagementPort.getByWriterIdAndDateBetween(
            DomainId.from(query.userId()),
            startDate,
            endDate
    );
```
- 자신의 5달 전부터 이번 달까지의 일기 조회

```java
    Map<Long, Map<Sentiment, Long>> barData = diaries.stream()
            .collect(Collectors.groupingBy(
                    diary -> -ChronoUnit.MONTHS.between(
                            YearMonth.from(diary.getDate()),
                            YearMonth.from(endDate)),
                    Collectors.groupingBy(
                            diary -> diary.getEmotion().getSentiment(),
                            Collectors.counting())
            ));
```
- 달별로 그룹핑, `Sentiment`로 다시 그룹핑해 막대 그래프 데이터 생성

```java
    LocalDate previousMonthLastDate = endDate.minusMonths(1)
                                             .withDayOfMonth(endDate.minusMonths(1).lengthOfMonth());

    Map<Emotion, Long> pieData = diaries.stream()
            .filter(diary -> diary.getDate().isAfter(previousMonthLastDate))
            .collect(Collectors.groupingBy(DiaryBasic::getEmotion, Collectors.counting()));

    return toEmotionStatsResponse(barData, pieData);
}
```
- 저번 달의 마지막 날짜 이후(이번 달)의 일기를 `Emotion`으로 그룹핑해 원형 그래프 데이터 생성

## 날짜 기반 일기 조회 메소드 수정
### DiaryManagementJpaAdapter
- `getByUserIdAndMonth(DomainId userId, LocalDate date)`를 `getByWriterIdAndDateBetween(DomainId userId, LocalDate start, LocalDate end)`로 수정
### DiaryQueryService
- 수정한 메소드를 감정 통계 조회에서도 사용

## 픽셀 아트 프롬프트 수정
### Style
```java
PIXELART("8-bit graphics", "픽셀 아트",  ...
```
- 프롬프트를 `retro graphics`에서 `8-bit graphics`로 수정
- 결과물
  - ![image](https://github.com/user-attachments/assets/b7c7eca7-fab3-45f4-8c5b-7da24d66cecf)

# 참고한 글
- [[Java] Stream 데이터 groupingBy 예제](https://umanking.github.io/2021/07/31/java-stream-grouping-by-example/)
- [[Java] API - LocalDate withDayOfMonth() 월의 첫날과 마지막 날 가져오기](https://m.blog.naver.com/seek316/222319652865)