### PR TITLE
feat: weightedContents DB 저장 및 반환 형태 변경

### DIFF
--- a/Domain-Module/src/main/java/com/canvas/domain/diary/entity/DiaryComplete.java
+++ b/Domain-Module/src/main/java/com/canvas/domain/diary/entity/DiaryComplete.java
@@ -114,6 +114,9 @@ public class DiaryComplete {
     }
 
     public String getJoinedWeightedContents() {
+        if (weightedContents.isEmpty()) {
+            return null;
+        }
         return String.join(",", weightedContents);
     }
 

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/DiaryMapper.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/DiaryMapper.java
@@ -7,8 +7,6 @@ import com.canvas.domain.diary.entity.DiaryOverview;
 import com.canvas.domain.diary.enums.Emotion;
 import com.canvas.persistence.jpa.diary.entity.DiaryEntity;
 
-import java.util.Arrays;
-
 public class DiaryMapper {
     public static DiaryEntity toEntity(DiaryComplete diary) {
         DiaryEntity diaryEntity = new DiaryEntity(
@@ -61,7 +59,7 @@ public class DiaryMapper {
                 DomainId.from(diaryEntity.getId()),
                 DomainId.from(diaryEntity.getWriterId()),
                 diaryEntity.getContent(),
-                Arrays.stream(diaryEntity.getJoinedWeightedContents().split(",")).toList(),
+                diaryEntity.getWeightedContents(),
                 Emotion.parse(diaryEntity.getEmotion()),
                 diaryEntity.getDate(),
                 diaryEntity.getCreatedAt(),

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/entity/DiaryEntity.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/entity/DiaryEntity.java
@@ -64,4 +64,11 @@ public class DiaryEntity extends BaseEntity {
 
     public void addDiaryKeywordEntity(DiaryKeywordEntity diaryKeywordEntity) {diaryKeywordEntities.add(diaryKeywordEntity);}
 
+    public List<String> getWeightedContents() {
+        if (joinedWeightedContents == null) {
+            return List.of();
+        }
+        return List.of(joinedWeightedContents.split(","));
+    }
+
 }


### PR DESCRIPTION
# 이슈
- #102

# 구현 내용
- 강조한 내용이 없는 경우 DB에 빈 문자열 대신 null 저장
- 강조한 내용이 없는 경우 일기 조회 시 빈 문자열이 들어있는 리스트 대신 빈 리스트 반환
- 엔티티로부터 `weightedContents` 리스트 추출 로직 `DiaryEntity`로 이동