### PR TITLE
feat: 인증 필터 예외 처리

### DIFF
--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/common/exception/ExceptionResponse.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/common/exception/ExceptionResponse.java
@@ -7,6 +7,6 @@ public record ExceptionResponse(
         String message
 ) {
     public static ExceptionResponse of(BusinessException e) {
-        return new ExceptionResponse(e.getMessage(), e.getErrorCode());
+        return new ExceptionResponse(e.getErrorCode(), e.getMessage());
     }
 }

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/common/filter/exception/AuthenticationException.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/common/filter/exception/AuthenticationException.java
@@ -1,0 +1,20 @@
+package com.canvas.bootstrap.common.filter.exception;
+
+import com.canvas.common.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class AuthenticationException extends BusinessException {
+
+    private static final String CODE_PREFIX = "AUTH";
+    private static final String DEFAULT_MESSAGE = "인증 예외가 발생했습니다.";
+    private static final HttpStatus DEFAULT_HTTP_STATUS = HttpStatus.UNAUTHORIZED;
+
+    public AuthenticationException() {
+        super(CODE_PREFIX, 0, DEFAULT_HTTP_STATUS, DEFAULT_MESSAGE);
+    }
+
+    public AuthenticationException(int errorCode, HttpStatus httpStatus, String message) {
+        super(CODE_PREFIX, errorCode, httpStatus, message);
+    }
+
+}


### PR DESCRIPTION
# 이슈
- #60 

# 구현한 내용
- 인증 예외 생성 및 적용
- 필터 예외 처리
- 예외 응답 속성 순서 수정
- 필터 이름 변경

# 세부 내용
## 인증 예외 생성 및 적용
### AuthenticationFilter
```java
String authorization = request.getHeader(AUTHORIZATION_HEADER);
if (authorization == null || !authorization.startsWith(BEARER_PREFIX)) {
    throw new AuthenticationException();
}
```
- 토큰 헤더가 없거나 형태가 일치하지 않을 때 `AuthenticationException`을 던짐

## 필터 예외 처리
### ExceptionHandlerFilter
```java
response.setContentType("application/json;charset=UTF-8");
response.setCharacterEncoding("UTF-8");
```
- UTF-8 인코딩으로 한글이 깨지는 문제 해결

```java
if (e instanceof BusinessException exception) {
    return exception.getHttpStatus().value();
}
```
```java
if (exception instanceof BusinessException e) {
    log.error("message={}, code={}", e.getMessage(), e.getErrorCode());
    ExceptionResponse errorResponse = ExceptionResponse.of(e);
    response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
    return;
}
```
- BusinessException을 상속한 사용자 예외일 경우 에러 코드와 메시지 그대로 사용

# 참고한 글
- [Java Equals 정의시 getClass() or instanceof](https://shinscode.tistory.com/entry/Java-Equals-%EC%A0%95%EC%9D%98%EC%8B%9C-getClass-or-instanceof)

close #60 