### PR TITLE
feat: preflight 요청 예외 처리

### DIFF
--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/common/filter/AuthenticationFilter.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/common/filter/AuthenticationFilter.java
@@ -11,6 +11,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.util.PathMatcher;
@@ -42,7 +43,7 @@ public class AuthenticationFilter extends OncePerRequestFilter {
         // 제외 되는 경로 검증
         String requestURI = request.getRequestURI();
 
-        if (isExcludedPath(requestURI)) {
+        if (isExcludedPath(requestURI) || request.getMethod().equals(HttpMethod.OPTIONS.name())) {
             filterChain.doFilter(request, response);
             return;
         }


### PR DESCRIPTION
# 이슈
- #60 

# 구현 내용
- 인증 필터에서 preflight 요청 예외 처리

# 세부 내용
### AuthenticationFilter
```java
if (isExcludedPath(requestURI) || request.getMethod().equals(HttpMethod.OPTIONS.name())) {
    filterChain.doFilter(request, response);
    return;
}
```
- 요청 메소드가 `OPTIONS`인 경우 다음 필터로 전달

# 참고한 글
- [CORS의 기본 개념과 동작 방식(부제: Preflight 요청이란?)](https://velog.io/@wjdwl002/CORS%EC%9D%98-%EA%B8%B0%EB%B3%B8-%EA%B0%9C%EB%85%90%EA%B3%BC-%EB%8F%99%EC%9E%91-%EB%B0%A9%EC%8B%9D%EB%B6%80%EC%A0%9C-Preflight-%EC%9A%94%EC%B2%AD%EC%9D%B4%EB%9E%80)
- [[Server] CORS Preflight 에러](https://velog.io/@gksrywls97/Server-CORS-Preflight-%EC%97%90%EB%9F%AC)
