### PR TITLE
feat: spring actuator 의존성, health check api 추가

### DIFF
--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/common/filter/AuthenticationFilter.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/common/filter/AuthenticationFilter.java
@@ -34,6 +34,7 @@ public class AuthenticationFilter extends OncePerRequestFilter {
         excludedAuthUrls.add("/api/v1/auth/**");
         excludedAuthUrls.add("/swagger-ui/**");
         excludedAuthUrls.add("/v3/api-docs/**");
+        excludedAuthUrls.add("/actuator/**");
     }
 
     private final PathMatcher pathMatcher = new AntPathMatcher();

--- a/Infrastructure-Module/Persistence/build.gradle
+++ b/Infrastructure-Module/Persistence/build.gradle
@@ -3,5 +3,8 @@ dependencies {
     runtimeOnly("com.mysql:mysql-connector-j")
 
     testRuntimeOnly("com.h2database:h2")
+
+    // actuator
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 }
 


### PR DESCRIPTION
# 이슈
- #129 

# 구현 내용
- Spring Actuator 의존성 추가 및 health check API 노출

# 세부 내용
### AuthenticationFilter
- 인증 제외 규칙에 `/actuator/**` 추가

### health check
- `/actuator/health`로 현재 어플리케이션의 상태 확인
  - AWS 대상 그룹의 health check에 사용

# 고민한 내용
## health check API 하나만을 위해 Spring Actuator를 추가해야 하는가?
```java
@RestController
@RequestMapping("/health")
public class HealthController {

    @GetMapping
    public ResponseEntity<String> healthCheck() {
        return ResponseEntity.ok("OK");
    }
}
```
- 단순히 서비스 구동 상태만 확인하려면 커스텀 API를 만들어도 된다.
- 하지만 spring actuator는 DB의 상태도 자동으로 포함해 전체 서비스의 가용 상태를 알려준다.
- 나중에 health check 조건도 쉽게 추가할 수 있고, 모니터링을 쉽게 할 수 있기 때문에 Spring Actuator를 사용하기로 결정하였다.

# 참고한 글
- [Actuator REST API](https://docs.spring.io/spring-boot/api/rest/actuator/index.html)
- [스프링 부트 - 액추에이터](https://velog.io/@zenon8485/%EC%8A%A4%ED%94%84%EB%A7%81-%EB%B6%80%ED%8A%B8-%EC%95%A1%EC%B6%94%EC%97%90%EC%9D%B4%ED%84%B0)
- [Spring Boot Actuator의 헬스체크 살펴보기](https://toss.tech/article/how-to-work-health-check-in-spring-boot-actuator)

close #129 