### PR TITLE
feat: 이미지가 없는 일기에서 이미지 생성 시 메인 이미지로 설정

### DIFF
--- a/Application-Module/src/main/java/com/canvas/application/image/service/ImageCommandService.java
+++ b/Application-Module/src/main/java/com/canvas/application/image/service/ImageCommandService.java
@@ -45,7 +45,7 @@ public class ImageCommandService
                 ));
 
         Image image = Image.create(DomainId.generate(),
-                                   diaryId, false, create.imageUrl());
+                                   diaryId, !diary.hasImage(), create.imageUrl());
 
         imageManagementPort.save(image);
 

--- a/Domain-Module/src/main/java/com/canvas/domain/diary/entity/DiaryComplete.java
+++ b/Domain-Module/src/main/java/com/canvas/domain/diary/entity/DiaryComplete.java
@@ -105,6 +105,10 @@ public class DiaryComplete {
         return writerId.value().equals(userId.value());
     }
 
+    public boolean hasImage() {
+        return !images.isEmpty();
+    }
+
     public String getMainImageOrDefault() {
         return images.stream()
                      .filter(Image::isMain)

--- a/Infrastructure-Module/ImageGenerator/src/main/java/com/canvas/generator/flux/FluxClient.java
+++ b/Infrastructure-Module/ImageGenerator/src/main/java/com/canvas/generator/flux/FluxClient.java
@@ -2,6 +2,8 @@ package com.canvas.generator.flux;
 
 import com.canvas.generator.flux.exception.FluxException;
 import com.canvas.generator.flux.exception.FluxResultStatus;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -48,6 +50,7 @@ public class FluxClient {
     }
 
     public String getResult(String id) {
+        log.info("id={}", id);
         return Objects.requireNonNull(webClient.get()
                 .uri(uriBuilder -> uriBuilder.path("/get_result")
                         .queryParam("id", id)
@@ -65,6 +68,7 @@ public class FluxClient {
                 .getSample();
     }
 
+    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
     public record GenerateRequest(
             String prompt,
             Integer width,


### PR DESCRIPTION
# 이슈
- #133 

# 구현 내용
- 이미지가 없는 일기에서 이미지 생성 시 메인 이미지로 설정
- Flux API 요청 형식 snake case 적용

close #133 