### PR TITLE
fix: fetch join으로 query 수정

### DIFF
--- a/Application-Module/src/main/java/com/canvas/application/keyword/port/out/DiaryKeywordManagementPort.java
+++ b/Application-Module/src/main/java/com/canvas/application/keyword/port/out/DiaryKeywordManagementPort.java
@@ -5,8 +5,9 @@ import com.canvas.domain.keyword.DiaryKeyword;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 
 public interface DiaryKeywordManagementPort {
     void saveAllDiaryKeywords(List<DiaryKeyword> diaryKeywords);
-    List<DiaryKeyword> findByWriteIdAndBetween(DomainId userId, LocalDate start, LocalDate end);
+    Map<String, Long> findDiaryKeywordByWriterIdAndDateRange(DomainId userId, LocalDate start, LocalDate end);
 }

--- a/Application-Module/src/main/java/com/canvas/application/keyword/port/out/KeywordManagementPort.java
+++ b/Application-Module/src/main/java/com/canvas/application/keyword/port/out/KeywordManagementPort.java
@@ -1,6 +1,5 @@
 package com.canvas.application.keyword.port.out;
 
-import com.canvas.domain.common.DomainId;
 import com.canvas.domain.keyword.Keyword;
 
 import java.util.List;
@@ -9,6 +8,4 @@ public interface KeywordManagementPort {
     void saveAllKeywords(List<Keyword> keywords);
 
     List<Keyword> findAllByNames(List<String> keywords);
-
-    List<Keyword> findByKeywordsId(List<DomainId> ids);
 }

--- a/Application-Module/src/main/java/com/canvas/application/keyword/service/KeywordQueryService.java
+++ b/Application-Module/src/main/java/com/canvas/application/keyword/service/KeywordQueryService.java
@@ -42,28 +42,10 @@ public class KeywordQueryService implements GetKeywordStatsUseCase {
     }
 
     private Response getKeywordStats(String userId, LocalDate startDate, LocalDate endDate) {
-        List<DiaryKeyword> diaryKeywords = diaryKeywordManagementPort.findByWriteIdAndBetween(
-                DomainId.from(userId),
-                startDate,
-                endDate
-        );
 
-        List<DomainId> keywordIds = diaryKeywords.stream()
-                .map(DiaryKeyword::getKeywordId)
-                .distinct()
-                .toList();
 
-        List<Keyword> keywords = keywordManagementPort.findByKeywordsId(keywordIds);
-
-        Map<String, Long> keywordNameCounts = diaryKeywords.stream()
-                .flatMap(diaryKeyword -> keywords.stream()
-                        .filter(keyword -> keyword.getId().equals(diaryKeyword.getKeywordId()))
-                        .map(Keyword::getKeyword)
-                )
-                .collect(Collectors.groupingBy(
-                        keywordName -> keywordName,
-                        Collectors.counting()
-                ));
+        Map<String, Long> keywordNameCounts = diaryKeywordManagementPort.
+                findDiaryKeywordByWriterIdAndDateRange(DomainId.from(userId), startDate, endDate);
 
         return toKeywordStatsResponse(keywordNameCounts);
     }

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/adapter/KeywordManagementJpaAdapter.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/adapter/KeywordManagementJpaAdapter.java
@@ -16,7 +16,9 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Repository
 @RequiredArgsConstructor
@@ -31,14 +33,6 @@ public class KeywordManagementJpaAdapter implements KeywordManagementPort, Diary
         return keywordEntities.stream().map(KeywordMapper::toDomain).toList();
     }
 
-    @Override
-    public List<Keyword> findByKeywordsId(List<DomainId> keywordIdList) {
-        List<UUID> keywordIds = keywordIdList.stream().map(DomainId::value).toList();
-        return keywordJpaRepository.findByKeywordIds(keywordIds)
-                .stream()
-                .map(KeywordMapper::toDomain)
-                .toList();
-    }
 
     @Override
     public void saveAllKeywords(List<Keyword> keywords) {
@@ -52,12 +46,14 @@ public class KeywordManagementJpaAdapter implements KeywordManagementPort, Diary
         diaryKeywordJpaRepository.saveAll(diaryKeywordEntities);
     }
 
+
     @Override
-    public List<DiaryKeyword> findByWriteIdAndBetween(DomainId userId, LocalDate start, LocalDate end) {
-        List<DiaryKeywordEntity> diaryKeywordEntities =
-                diaryKeywordJpaRepository.getByWriteIdAndBetween(userId.value(), start, end);
+    public Map<String, Long> findDiaryKeywordByWriterIdAndDateRange(DomainId userId, LocalDate start, LocalDate end) {
+        List<DiaryKeywordEntity> diaryKeywordEntities = diaryKeywordJpaRepository.findByWriterIdAndDateRange(userId.value(), start, end);
         return diaryKeywordEntities.stream()
-                .map(DiaryKeywordMapper::toDomain)
-                .toList();
+                .map(diaryKeywordEntity -> diaryKeywordEntity.getKeywordEntity().getName())
+                .collect(Collectors.groupingBy(
+                        name -> name,
+                        Collectors.counting()));
     }
 }

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/repository/DiaryKeywordJpaRepository.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/repository/DiaryKeywordJpaRepository.java
@@ -11,14 +11,13 @@ import java.util.UUID;
 public interface DiaryKeywordJpaRepository extends JpaRepository<DiaryKeywordEntity, UUID> {
 
     @Query("""
-        select dk
-        from DiaryKeywordEntity dk
-        where dk.diaryId in (
-                        select d.id
-                        from DiaryEntity d
-                        where d.writerId = :writerId and d.date between :startDate and :endDate
-                        )
-    """)
-    List<DiaryKeywordEntity> getByWriteIdAndBetween(UUID writerId, LocalDate startDate, LocalDate endDate);
+    select dk
+    from DiaryKeywordEntity dk
+    join fetch dk.keywordEntity k
+    where dk.diaryEntity.writerId = :writerId
+      and dk.diaryEntity.date between :startDate and :endDate
+""")
+    List<DiaryKeywordEntity> findByWriterIdAndDateRange(UUID writerId, LocalDate startDate, LocalDate endDate);
+
 
 }

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/repository/KeywordJpaRepository.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/repository/KeywordJpaRepository.java
@@ -4,6 +4,7 @@ import com.canvas.persistence.jpa.diary.entity.KeywordEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
@@ -15,12 +16,5 @@ public interface KeywordJpaRepository extends JpaRepository<KeywordEntity, UUID>
         where k.name in (:names)
     """)
     List<KeywordEntity> findByKeywords(List<String> names);
-
-    @Query("""
-        select k
-        from KeywordEntity k
-        where k.id in (:keywordIds)
-    """)
-    List<KeywordEntity> findByKeywordIds(List<UUID> keywordIds);
 
 }


### PR DESCRIPTION
# 구현 내용
- [x] fetch join으로 쿼리 수정

# 고민 내용
- 현재 세번의 쿼리로 나눠서 처리하는 로직을 한번에 fetch join으로 가져와서 처리하도록 변경
- default_batch_fetch_size로 인해 in 절로 keyword 엔티티를 가져오는 부분에서 성능 상 좋지 않을 것 같아 fetch join으로 keyword에 관련된 내용도 가지고 오도록 하여 n + 1 문제와 불필요한 in 절 문제 해결