### PR TITLE
refactor: 일기 수정 로직 리팩토링

### DIFF
--- a/Application-Module/src/main/java/com/canvas/application/diary/port/out/DiaryManagementPort.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/port/out/DiaryManagementPort.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 
 public interface DiaryManagementPort {
     DiaryComplete save(DiaryComplete diary);
+    void update(DiaryComplete diary);
     boolean existsByWriterIdAndDate(DomainId userId, LocalDate date);
     DiaryComplete getById(DomainId diaryId);
     DiaryComplete getByIdAndWriterId(DomainId diaryId, DomainId writerId);

--- a/Application-Module/src/main/java/com/canvas/application/diary/service/DiaryCommandService.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/service/DiaryCommandService.java
@@ -79,7 +79,7 @@ public class DiaryCommandService
         diary.updateWeightedContents(command.weightedContents());
         diary.updatePublic(command.isPublic());
 
-        diaryManagementPort.save(diary);
+        diaryManagementPort.update(diary);
     }
 
     private Image createImage(DomainId diaryId, String content, String joinedWeightedContents, Style style) {

--- a/Application-Module/src/test/java/com/canvas/application/diary/service/DiaryCommandServiceTest.java
+++ b/Application-Module/src/test/java/com/canvas/application/diary/service/DiaryCommandServiceTest.java
@@ -116,7 +116,7 @@ class DiaryCommandServiceTest {
 
         // then
         verify(diaryEmotionExtractPort, never()).emotionExtract(command.content());
-        verify(diaryManagementPort).save(diary);
+        verify(diaryManagementPort).update(diary);
         assertThat(diary.getContent()).isEqualTo(command.content());
         assertThat(diary.getIsPublic()).isEqualTo(command.isPublic());
     }
@@ -141,7 +141,7 @@ class DiaryCommandServiceTest {
 
         // then
         verify(diaryEmotionExtractPort).emotionExtract(command.content());
-        verify(diaryManagementPort).save(diary);
+        verify(diaryManagementPort).update(diary);
         assertThat(diary.getContent()).isEqualTo(command.content());
         assertThat(diary.getIsPublic()).isEqualTo(command.isPublic());
     }

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/controller/DiaryController.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/diary/controller/DiaryController.java
@@ -72,8 +72,6 @@ public class DiaryController implements DiaryApi {
                         .toList());
     }
 
-    // 그날의 일기 일기 다시 재생성
-    // 일기 수정할 때 그림 자체를 재생성하는데, 일기 내용 수정만 하는 경우도 생각해야 할 것 같음.
     @Override
     public void updateDiary(String userId, String diaryId, UpdateDiaryRequest request) {
         modifyDiaryUseCase.modify(new ModifyDiaryUseCase.Command(

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/adapter/DiaryManagementJpaAdapter.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/adapter/DiaryManagementJpaAdapter.java
@@ -33,6 +33,14 @@ public class DiaryManagementJpaAdapter implements DiaryManagementPort {
     }
 
     @Override
+    public void update(DiaryComplete diary) {
+        DiaryEntity diaryEntity = diaryJpaRepository.findById(diary.getId().value())
+                .orElseThrow(DiaryException.DiaryNotFoundException::new);
+
+        diaryEntity.update(DiaryMapper.toEntity(diary));
+    }
+
+    @Override
     public boolean existsByWriterIdAndDate(DomainId userId, LocalDate date) {
         return diaryJpaRepository.existsByWriterIdAndDate(userId.value(), date);
     }

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/entity/DiaryEntity.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/entity/DiaryEntity.java
@@ -71,4 +71,11 @@ public class DiaryEntity extends BaseEntity {
         return List.of(joinedWeightedContents.split(","));
     }
 
+    public void update(DiaryEntity diaryEntity) {
+        this.content = diaryEntity.getContent();
+        this.joinedWeightedContents = diaryEntity.getJoinedWeightedContents();
+        this.emotion = diaryEntity.getEmotion();
+        this.isPublic = diaryEntity.getIsPublic();
+    }
+
 }


### PR DESCRIPTION
# 이슈
- #138

# 구현 내용
- 일기 수정 로직 리팩토링

# 세부 내용
### DiaryCommandService
- 이전에는 생성, 수정 시 모두 `JpaRepository.save()` 메소드를 사용
- 기존 엔티티가 있으면 생성 대신 병합을 수행, 변하지 않아야 하는 데이터가 덮어씌워질 수 있음
```java
diaryManagementPort.update(diary);
```
- 더티 체킹을 사용한 수정으로 리팩토링

### DiaryManagerJpaAdapter
```java
@Override
public void update(DiaryComplete diary) {
    DiaryEntity diaryEntity = diaryJpaRepository.findById(diary.getId().value())
            .orElseThrow(DiaryException.DiaryNotFoundException::new);

    diaryEntity.update(DiaryMapper.toEntity(diary));
}
```
### DiaryEntity
```java
public void update(DiaryEntity diaryEntity) {
    this.content = diaryEntity.getContent();
    this.joinedWeightedContents = diaryEntity.getJoinedWeightedContents();
    this.emotion = diaryEntity.getEmotion();
    this.isPublic = diaryEntity.getIsPublic();
}
```
- `update` 메소드 추가

close #138