### PR TITLE
feat: 이미지 삭제 시 S3에서도 삭제

### DIFF
--- a/Application-Module/src/main/java/com/canvas/application/diary/port/out/DiaryManagementPort.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/port/out/DiaryManagementPort.java
@@ -18,7 +18,6 @@ public interface DiaryManagementPort {
     boolean existsByWriterIdAndDate(DomainId userId, LocalDate date);
     DiaryComplete getById(DomainId diaryId);
     DiaryComplete getByIdAndWriterId(DomainId diaryId, DomainId writerId);
-    boolean existsByIdAndWriterId(DomainId diaryId, DomainId writerId);
     List<DiaryBasic> getByWriterIdAndDateBetween(DomainId userId, LocalDate start, LocalDate end);
     Slice<DiaryOverview> getAlbum(PageRequest pageRequest, DomainId userId);
     Slice<DiaryOverview> getAlbumByContent(PageRequest pageRequest, DomainId userId, String content);

--- a/Application-Module/src/main/java/com/canvas/application/diary/service/DiaryCommandService.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/service/DiaryCommandService.java
@@ -9,6 +9,7 @@ import com.canvas.application.diary.port.in.RemoveDiaryUseCase;
 import com.canvas.application.diary.port.out.DiaryEmotionExtractPort;
 import com.canvas.application.diary.port.out.DiaryManagementPort;
 import com.canvas.application.image.port.in.AddImageUseCase;
+import com.canvas.application.image.port.out.ImageStoragePort;
 import com.canvas.domain.common.DomainId;
 import com.canvas.domain.diary.entity.DiaryComplete;
 import com.canvas.domain.diary.entity.Image;
@@ -29,6 +30,7 @@ public class DiaryCommandService
     private final DiaryManagementPort diaryManagementPort;
     private final DiaryEmotionExtractPort diaryEmotionExtractPort;
     private final AddImageUseCase addImageUseCase;
+    private final ImageStoragePort imageStoragePort;
     private final ApplicationEventPublisher eventPublisher;
 
     @Override
@@ -90,14 +92,13 @@ public class DiaryCommandService
 
     @Override
     public void remove(RemoveDiaryUseCase.Command command) {
-        if (!diaryManagementPort.existsByIdAndWriterId(
+        DiaryComplete diary = diaryManagementPort.getByIdAndWriterId(
                 DomainId.from(command.diaryId()),
                 DomainId.from(command.userId())
-        )) {
-            throw new DiaryException.DiaryForbiddenException();
-        }
+        );
 
         diaryManagementPort.deleteById(DomainId.from(command.diaryId()));
+        diary.getImageUrls().forEach(imageStoragePort::delete);
     }
 
 }

--- a/Application-Module/src/main/java/com/canvas/application/image/port/out/ImageManagementPort.java
+++ b/Application-Module/src/main/java/com/canvas/application/image/port/out/ImageManagementPort.java
@@ -8,7 +8,7 @@ import java.util.List;
 public interface ImageManagementPort {
     Image save(Image image);
     List<Image> saveAll(List<Image> images);
-    boolean existsByIdAndUserId(DomainId imageId, DomainId userId);
+    Image getByIdAndUserId(DomainId imageId, DomainId userId);
     List<Image> getAllInDiaryByIdAndWriterId(DomainId imageId, DomainId userId);
     void deleteById(DomainId imageId);
 }

--- a/Application-Module/src/main/java/com/canvas/application/image/port/out/ImageStoragePort.java
+++ b/Application-Module/src/main/java/com/canvas/application/image/port/out/ImageStoragePort.java
@@ -2,4 +2,5 @@ package com.canvas.application.image.port.out;
 
 public interface ImageStoragePort {
     String upload(String imageUrl);
+    void delete(String imageUrl);
 }

--- a/Application-Module/src/main/java/com/canvas/application/image/port/out/ImageStoragePort.java
+++ b/Application-Module/src/main/java/com/canvas/application/image/port/out/ImageStoragePort.java
@@ -1,5 +1,5 @@
 package com.canvas.application.image.port.out;
 
-public interface ImageUploadPort {
+public interface ImageStoragePort {
     String upload(String imageUrl);
 }

--- a/Application-Module/src/main/java/com/canvas/application/image/service/ImageCommandService.java
+++ b/Application-Module/src/main/java/com/canvas/application/image/service/ImageCommandService.java
@@ -8,7 +8,7 @@ import com.canvas.application.image.port.in.SetMainImageUseCase;
 import com.canvas.application.image.port.out.ImageGenerationPort;
 import com.canvas.application.image.port.out.ImageManagementPort;
 import com.canvas.application.image.port.out.ImagePromptGeneratePort;
-import com.canvas.application.image.port.out.ImageUploadPort;
+import com.canvas.application.image.port.out.ImageStoragePort;
 import com.canvas.domain.common.DomainId;
 import com.canvas.domain.diary.entity.DiaryComplete;
 import com.canvas.domain.diary.entity.Image;
@@ -28,7 +28,7 @@ public class ImageCommandService
     private final ImageGenerationPort imageGenerationPort;
     private final ImageManagementPort imageManagementPort;
     private final ImagePromptGeneratePort imagePromptGeneratePort;
-    private final ImageUploadPort imageUploadPort;
+    private final ImageStoragePort imageStoragePort;
 
     // 이미지를 생성하고 저장하면 add
     @Override
@@ -57,7 +57,7 @@ public class ImageCommandService
     public Response.Create create(AddImageUseCase.Command.Create command) {
         String prompt = imagePromptGeneratePort.generatePrompt(command.content(), command.joinedWeightedContents());
         String generatedImageUrl = imageGenerationPort.generate(prompt, command.style());
-        String uploadedImageUrl = imageUploadPort.upload(generatedImageUrl);
+        String uploadedImageUrl = imageStoragePort.upload(generatedImageUrl);
         return new Response.Create(uploadedImageUrl);
     }
 

--- a/Application-Module/src/main/java/com/canvas/application/image/service/ImageCommandService.java
+++ b/Application-Module/src/main/java/com/canvas/application/image/service/ImageCommandService.java
@@ -63,13 +63,13 @@ public class ImageCommandService
 
     @Override
     public void remove(RemoveImageUseCase.Command command) {
-        if (!imageManagementPort.existsByIdAndUserId(
-                DomainId.from(command.imageId()),
-                DomainId.from(command.userId()))) {
-            throw new ImageException.ImageNotFoundException();
-        }
+        DomainId imageId = DomainId.from(command.imageId());
+        DomainId userId = DomainId.from(command.userId());
 
-        imageManagementPort.deleteById(DomainId.from(command.imageId()));
+        Image image = imageManagementPort.getByIdAndUserId(imageId, userId);
+
+        imageManagementPort.deleteById(imageId);
+        imageStoragePort.delete(image.getImageUrl());
     }
 
     @Override

--- a/Application-Module/src/test/java/com/canvas/application/image/service/ImageCommandServiceTest.java
+++ b/Application-Module/src/test/java/com/canvas/application/image/service/ImageCommandServiceTest.java
@@ -8,7 +8,7 @@ import com.canvas.application.image.port.in.SetMainImageUseCase;
 import com.canvas.application.image.port.out.ImageGenerationPort;
 import com.canvas.application.image.port.out.ImageManagementPort;
 import com.canvas.application.image.port.out.ImagePromptGeneratePort;
-import com.canvas.application.image.port.out.ImageUploadPort;
+import com.canvas.application.image.port.out.ImageStoragePort;
 import com.canvas.domain.diary.entity.DiaryComplete;
 import com.canvas.domain.diary.entity.DiaryOverview;
 import com.canvas.domain.diary.entity.Image;
@@ -45,7 +45,7 @@ class ImageCommandServiceTest {
     @Mock
     private ImagePromptGeneratePort imagePromptGeneratePort;
     @Mock
-    private ImageUploadPort imageUploadPort;
+    private ImageStoragePort imageStoragePort;
 
     @Spy
     @InjectMocks
@@ -81,7 +81,7 @@ class ImageCommandServiceTest {
 
         given(imagePromptGeneratePort.generatePrompt(command.content(), command.joinedWeightedContents())).willReturn("prompt");
         given(imageGenerationPort.generate("prompt", command.style())).willReturn("generatedImageUrl");
-        given(imageUploadPort.upload("generatedImageUrl")).willReturn("uploadedImageUrl");
+        given(imageStoragePort.upload("generatedImageUrl")).willReturn("uploadedImageUrl");
 
         // when
         AddImageUseCase.Response.Create response = imageCommandService.create(command);

--- a/Application-Module/src/test/java/com/canvas/application/image/service/ImageCommandServiceTest.java
+++ b/Application-Module/src/test/java/com/canvas/application/image/service/ImageCommandServiceTest.java
@@ -98,7 +98,7 @@ class ImageCommandServiceTest {
         Image image = PUBLIC_MY_DIARY_IMAGE2.getImage();
         RemoveImageUseCase.Command command = getRemoveImageCommand(user, image);
 
-        given(imageManagementPort.existsByIdAndUserId(image.getId(), user.getId())).willReturn(true);
+        given(imageManagementPort.getByIdAndUserId(image.getId(), user.getId())).willReturn(image);
 
         // when
         imageCommandService.remove(command);
@@ -115,7 +115,8 @@ class ImageCommandServiceTest {
         Image image = PUBLIC_MY_DIARY_IMAGE2.getImage();
         RemoveImageUseCase.Command command = getRemoveImageCommand(user, image);
 
-        given(imageManagementPort.existsByIdAndUserId(image.getId(), user.getId())).willReturn(false);
+        given(imageManagementPort.getByIdAndUserId(image.getId(), user.getId()))
+                .willThrow(ImageException.ImageNotFoundException.class);
 
         // when
         // then

--- a/Domain-Module/src/main/java/com/canvas/domain/diary/entity/DiaryComplete.java
+++ b/Domain-Module/src/main/java/com/canvas/domain/diary/entity/DiaryComplete.java
@@ -127,4 +127,10 @@ public class DiaryComplete {
     public void updateWeightedContents(List<String> weightedContents) {
         this.weightedContents = weightedContents;
     }
+
+    public List<String> getImageUrls() {
+        return images.stream()
+                     .map(Image::getImageUrl)
+                     .toList();
+    }
 }

--- a/Infrastructure-Module/AWS/src/main/java/com/canvas/aws/s3/ImageStorageS3Adapter.java
+++ b/Infrastructure-Module/AWS/src/main/java/com/canvas/aws/s3/ImageStorageS3Adapter.java
@@ -1,6 +1,6 @@
 package com.canvas.aws.s3;
 
-import com.canvas.application.image.port.out.ImageUploadPort;
+import com.canvas.application.image.port.out.ImageStoragePort;
 import io.awspring.cloud.s3.ObjectMetadata;
 import io.awspring.cloud.s3.S3Resource;
 import io.awspring.cloud.s3.S3Template;
@@ -22,7 +22,7 @@ import java.util.UUID;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class ImageUploadS3Adaptor implements ImageUploadPort {
+public class ImageStorageS3Adapter implements ImageStoragePort {
 
     private final S3Template s3Template;
     private static final String BUCKET_NAME = "canvas-diary";

--- a/Infrastructure-Module/AWS/src/main/java/com/canvas/aws/s3/S3Excpetion.java
+++ b/Infrastructure-Module/AWS/src/main/java/com/canvas/aws/s3/S3Excpetion.java
@@ -1,0 +1,32 @@
+package com.canvas.aws.s3;
+
+import com.canvas.common.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class S3Excpetion extends BusinessException {
+
+    private static final String CODE_PREFIX = "S3";
+    private static final String DEFAULT_MESSAGE = "S3 예외가 발생했습니다.";
+    private static final HttpStatus DEFAULT_HTTP_STATUS = org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+    public S3Excpetion() {
+        super(CODE_PREFIX, 0, DEFAULT_HTTP_STATUS, DEFAULT_MESSAGE);
+    }
+
+    public S3Excpetion(int errorCode, HttpStatus httpStatus, String message) {
+        super(CODE_PREFIX, errorCode, httpStatus, message);
+    }
+
+    public static class S3NotFoundException extends S3Excpetion {
+        public S3NotFoundException() {
+            super(1, HttpStatus.NOT_FOUND, "존재하지 않는 파일입니다.");
+        }
+    }
+
+    public static class S3UploadException extends S3Excpetion {
+        public S3UploadException() {
+            super(2, HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다.");
+        }
+    }
+
+}

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/adapter/DiaryManagementJpaAdapter.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/adapter/DiaryManagementJpaAdapter.java
@@ -60,11 +60,6 @@ public class DiaryManagementJpaAdapter implements DiaryManagementPort {
     }
 
     @Override
-    public boolean existsByIdAndWriterId(DomainId diaryId, DomainId writerId) {
-        return diaryJpaRepository.existsByIdAndWriterId(diaryId.value(), writerId.value());
-    }
-
-    @Override
     public List<DiaryBasic> getByWriterIdAndDateBetween(DomainId userId, LocalDate start, LocalDate end) {
         return diaryJpaRepository.findByWriterIdAndDateBetween(userId.value(), start, end).stream()
                                  .map(DiaryMapper::toBasicDomain)

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/adapter/ImageManagementJpaAdapter.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/adapter/ImageManagementJpaAdapter.java
@@ -1,5 +1,6 @@
 package com.canvas.persistence.jpa.diary.adapter;
 
+import com.canvas.application.image.exception.ImageException;
 import com.canvas.application.image.port.out.ImageManagementPort;
 import com.canvas.domain.common.DomainId;
 import com.canvas.domain.diary.entity.Image;
@@ -36,8 +37,10 @@ public class ImageManagementJpaAdapter implements ImageManagementPort {
     }
 
     @Override
-    public boolean existsByIdAndUserId(DomainId imageId, DomainId userId) {
-        return imageJpaRepository.existsByIdAndWriterId(imageId.value(), userId.value());
+    public Image getByIdAndUserId(DomainId imageId, DomainId userId) {
+        return imageJpaRepository.findByIdAndWriterId(imageId.value(), userId.value())
+                .map(ImageMapper::toDomain)
+                .orElseThrow(ImageException.ImageNotFoundException::new);
     }
 
     @Override

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/repository/ImageJpaRepository.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/diary/repository/ImageJpaRepository.java
@@ -5,16 +5,17 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface ImageJpaRepository extends JpaRepository<ImageEntity, UUID> {
     @Query("""
-        select case when (count(i) > 0) then true else false end
+        select i
         from ImageEntity i
         join i.diaryEntity d
         where i.id = :imageId and d.writerId = :userId
     """)
-    boolean existsByIdAndWriterId(UUID imageId, UUID userId);
+    Optional<ImageEntity> findByIdAndWriterId(UUID imageId, UUID userId);
 
     @Query("""
         select i

--- a/Infrastructure-Module/Persistence/src/test/java/com/canvas/persistence/jpa/diary/repository/ImageJpaRepositoryTest.java
+++ b/Infrastructure-Module/Persistence/src/test/java/com/canvas/persistence/jpa/diary/repository/ImageJpaRepositoryTest.java
@@ -16,6 +16,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static com.canvas.persistence.jpa.fixture.ImageEntityFixture.PUBLIC_MY_DIARY_IMAGE1;
@@ -57,9 +58,13 @@ class ImageJpaRepositoryTest {
         UserEntity myself = MYSELF.getUserEntity();
 
         // when
+        Optional<ImageEntity> imageEntity = imageJpaRepository.findByIdAndWriterId(
+                publicMyDiaryImage1.getId(),
+                myself.getId()
+        );
+
         // then
-        assertThat(imageJpaRepository.existsByIdAndWriterId(publicMyDiaryImage1.getId(), myself.getId()))
-                .isTrue();
+        assertThat(imageEntity).isPresent();
     }
 
     @Test
@@ -70,9 +75,13 @@ class ImageJpaRepositoryTest {
         UserEntity other1 = OTHER1.getUserEntity();
 
         // when
+        Optional<ImageEntity> imageEntity = imageJpaRepository.findByIdAndWriterId(
+                publicMyDiaryImage1.getId(),
+                other1.getId()
+        );
+
         // then
-        assertThat(imageJpaRepository.existsByIdAndWriterId(publicMyDiaryImage1.getId(), other1.getId()))
-                .isFalse();
+        assertThat(imageEntity).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
# 이슈
- #141 

# 구현 내용
- 이미지 삭제 시 S3에서 삭제
- 일기 삭제 시 이미지 S3에서 삭제
- 포트 이름 변경
- `ImageStorageS3Adapter` 리팩토링 및 예외 처리 

# 세부 내용
## 이미지 삭제 시 S3에서 삭제
### ImageStorageS3Adapter
```java
@Override
public void delete(String imageUrl) {
    String[] split = imageUrl.split("/");
    String key = split[split.length - 1];

    log.info("key={}", key);

    s3Template.deleteObject(BUCKET_NAME, key);
}
```
- imageUrl에서 key 추출 후 삭제

### ImageCommandService
```java
@Override
public void remove(RemoveImageUseCase.Command command) {
    DomainId imageId = DomainId.from(command.imageId());
    DomainId userId = DomainId.from(command.userId());

    Image image = imageManagementPort.getByIdAndUserId(imageId, userId);

    imageManagementPort.deleteById(imageId);
    imageStoragePort.delete(image.getImageUrl());
}
```
- 이미지 삭제 시 S3에서 삭제

## 일기 삭제 시 이미지 S3에서 삭제
### DiaryCommandService
```java
@Override
public void remove(RemoveDiaryUseCase.Command command) {
    DiaryComplete diary = diaryManagementPort.getByIdAndWriterId(
            DomainId.from(command.diaryId()),
            DomainId.from(command.userId())
    );

    diaryManagementPort.deleteById(DomainId.from(command.diaryId()));
    diary.getImageUrls().forEach(imageStoragePort::delete);
}
```
- 일기 삭제 시 모든 이미지 S3에서 삭제

close #141