### PR TITLE
feat: 하루 이미지 생성 횟수 제한

### DIFF
--- a/Application-Module/src/main/java/com/canvas/application/diary/service/DiaryCommandService.java
+++ b/Application-Module/src/main/java/com/canvas/application/diary/service/DiaryCommandService.java
@@ -39,19 +39,21 @@ public class DiaryCommandService
             throw new DiaryException.DiaryBadRequestException();
         }
 
-        if (diaryManagementPort.existsByWriterIdAndDate(DomainId.from(command.userId()), command.date())) {
+        DomainId userId = DomainId.from(command.userId());
+        if (diaryManagementPort.existsByWriterIdAndDate(userId, command.date())) {
             throw new DiaryException.DiaryBadRequestException();
         }
 
         DomainId diaryId = DomainId.generate();
+
         Emotion emotion = diaryEmotionExtractPort.emotionExtract(command.content());
         String joinedWeightedContents = String.join(",", command.weightedContents());
-        Image image = createImage(diaryId, command.content(), joinedWeightedContents, command.style());
+        Image image = createImage(userId, diaryId, command.content(), joinedWeightedContents, command.style());
 
         diaryManagementPort.save(
                 DiaryComplete.create(
                         diaryId,
-                        DomainId.from(command.userId()),
+                        userId,
                         command.content(),
                         command.weightedContents(),
                         emotion,
@@ -84,9 +86,9 @@ public class DiaryCommandService
         diaryManagementPort.update(diary);
     }
 
-    private Image createImage(DomainId diaryId, String content, String joinedWeightedContents, Style style) {
+    private Image createImage(DomainId userId, DomainId diaryId, String content, String joinedWeightedContents, Style style) {
         String imageUrl = addImageUseCase.create(
-                new AddImageUseCase.Command.Create(diaryId.toString(), content, joinedWeightedContents, style)).imageUrl();
+                new AddImageUseCase.Command.Create(userId.toString(), content, joinedWeightedContents, style)).imageUrl();
         return Image.create(DomainId.generate(), diaryId, true, imageUrl);
     }
 

--- a/Application-Module/src/main/java/com/canvas/application/image/exception/ImageException.java
+++ b/Application-Module/src/main/java/com/canvas/application/image/exception/ImageException.java
@@ -19,8 +19,13 @@ public class ImageException extends BusinessException {
 
     public static class ImageNotFoundException extends ImageException {
         public ImageNotFoundException() {
-            super(1, org.springframework.http.HttpStatus.NOT_FOUND, "존재하지 않는 이미지입니다.");
+            super(1, HttpStatus.NOT_FOUND, "존재하지 않는 이미지입니다.");
         }
     }
 
+    public static class ImageDailyLimitExceededException extends ImageException {
+        public ImageDailyLimitExceededException() {
+            super(2, HttpStatus.TOO_MANY_REQUESTS, "이미지 생성 제한을 초과했습니다.");
+        }
+    }
 }

--- a/Application-Module/src/main/java/com/canvas/application/image/port/in/AddImageUseCase.java
+++ b/Application-Module/src/main/java/com/canvas/application/image/port/in/AddImageUseCase.java
@@ -8,13 +8,14 @@ public interface AddImageUseCase {
 
     class Command {
         public record Add(
+                String userId,
                 String diaryId,
                 Style style
         ) {
         }
 
         public record Create(
-                String diaryId,
+                String userId,
                 String content,
                 String joinedWeightedContents,
                 Style style

--- a/Application-Module/src/main/java/com/canvas/application/image/port/out/ImageDailyLimitPort.java
+++ b/Application-Module/src/main/java/com/canvas/application/image/port/out/ImageDailyLimitPort.java
@@ -1,0 +1,10 @@
+package com.canvas.application.image.port.out;
+
+import com.canvas.domain.common.DomainId;
+
+public interface ImageDailyLimitPort {
+    boolean isExceed(DomainId userId);
+    void decrease(DomainId userId);
+    void increase(DomainId userId);
+    void reset(DomainId userId);
+}

--- a/Application-Module/src/testFixtures/java/com/canvas/application/image/ImageApplicationFixture.java
+++ b/Application-Module/src/testFixtures/java/com/canvas/application/image/ImageApplicationFixture.java
@@ -4,7 +4,6 @@ import com.canvas.application.common.enums.Style;
 import com.canvas.application.image.port.in.AddImageUseCase;
 import com.canvas.application.image.port.in.RemoveImageUseCase;
 import com.canvas.application.image.port.in.SetMainImageUseCase;
-import com.canvas.domain.common.DomainId;
 import com.canvas.domain.diary.entity.DiaryComplete;
 import com.canvas.domain.diary.entity.Image;
 import com.canvas.domain.user.entity.User;
@@ -12,14 +11,15 @@ import com.canvas.domain.user.entity.User;
 public class ImageApplicationFixture {
     public static AddImageUseCase.Command.Add getAddImageCommand(DiaryComplete diary) {
         return new AddImageUseCase.Command.Add(
+                diary.getWriterId().toString(),
                 diary.getId().toString(),
                 Style.PHOTOREALISTIC
         );
     }
 
-    public static AddImageUseCase.Command.Create getCreateImageCommand() {
+    public static AddImageUseCase.Command.Create getCreateImageCommand(User user) {
         return new AddImageUseCase.Command.Create(
-                DomainId.generate().toString(),
+                user.getId().toString(),
                 "content",
                 "joinedWeightedContents",
                 Style.PHOTOREALISTIC

--- a/Bootstrap-Module/src/main/java/com/canvas/bootstrap/image/controllor/ImageController.java
+++ b/Bootstrap-Module/src/main/java/com/canvas/bootstrap/image/controllor/ImageController.java
@@ -19,7 +19,7 @@ public class ImageController implements ImageApi {
     @Override
     public void createImage(String userId, String diaryId, CreateImageRequest createImageRequest) {
         addImageUseCase.add(
-                new AddImageUseCase.Command.Add(diaryId, createImageRequest.style()));
+                new AddImageUseCase.Command.Add(userId, diaryId, createImageRequest.style()));
     }
 
     @Override

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/dailylimit/adapter/ImageDailyLimitJpaAdapter.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/dailylimit/adapter/ImageDailyLimitJpaAdapter.java
@@ -1,0 +1,40 @@
+package com.canvas.persistence.jpa.dailylimit.adapter;
+
+import com.canvas.application.image.port.out.ImageDailyLimitPort;
+import com.canvas.domain.common.DomainId;
+import com.canvas.persistence.jpa.dailylimit.entity.DailyLimitEntity;
+import com.canvas.persistence.jpa.dailylimit.repository.DailyLimitJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Component
+@RequiredArgsConstructor
+public class ImageDailyLimitJpaAdapter implements ImageDailyLimitPort {
+
+    private static final int LIMIT = 5;
+
+    private final DailyLimitJpaRepository dailyLimitJpaRepository;
+
+    @Override
+    public boolean isExceed(DomainId userId) {
+        return dailyLimitJpaRepository.countByUserIdAndDate(userId.value(), LocalDate.now()) >= LIMIT;
+    }
+
+    @Override
+    public void decrease(DomainId userId) {
+        dailyLimitJpaRepository.save(new DailyLimitEntity(userId.value()));
+    }
+
+    @Override
+    public void increase(DomainId userId) {
+        dailyLimitJpaRepository.deleteDistinctByUserId(userId.value());
+    }
+
+    @Override
+    public void reset(DomainId userId) {
+        dailyLimitJpaRepository.deleteByUserId(userId.value());
+    }
+
+}

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/dailylimit/entity/DailyLimitEntity.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/dailylimit/entity/DailyLimitEntity.java
@@ -1,0 +1,34 @@
+package com.canvas.persistence.jpa.dailylimit.entity;
+
+import com.canvas.domain.common.DomainId;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Entity
+@Table(name = "daily_limit")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class DailyLimitEntity {
+
+    @Id
+    private UUID id;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+    private LocalDate date;
+
+    public DailyLimitEntity(UUID userId) {
+        this.id = DomainId.generate().value();
+        this.userId = userId;
+        this.date = LocalDate.now();
+    }
+
+}

--- a/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/dailylimit/repository/DailyLimitJpaRepository.java
+++ b/Infrastructure-Module/Persistence/src/main/java/com/canvas/persistence/jpa/dailylimit/repository/DailyLimitJpaRepository.java
@@ -1,0 +1,13 @@
+package com.canvas.persistence.jpa.dailylimit.repository;
+
+import com.canvas.persistence.jpa.dailylimit.entity.DailyLimitEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+public interface DailyLimitJpaRepository extends JpaRepository<DailyLimitEntity, UUID> {
+    int countByUserIdAndDate(UUID userId, LocalDate date);
+    void deleteDistinctByUserId(UUID userId);
+    void deleteByUserId(UUID userId);
+}


### PR DESCRIPTION
# 이슈
- #142 

# 구현 내용
- 이미지 생성 시 하루 최대 생성 횟수 제한
- 일기 생성 시 하루 최대 생성 횟수 제한

# 세부 내용
### ImageCommandService
```java
@Override
public Response.Create create(AddImageUseCase.Command.Create command) {
    if (imageDailyLimitPort.isExceed(DomainId.from(command.userId()))) {
        throw new ImageException.ImageDailyLimitExceededException();
    }

    imageDailyLimitPort.decrease(DomainId.from(command.userId()));
    ...
}
```
- 최대 작성 횟수를 넘으면 `ImageDailyLimitExceededException`를 던지고 HTTP 상태 코드 429로 응답
- 이미지 생성 시마다 횟수 차감

### ImageDailyLimitJpaAdapter
- 현재는 JPA(MySQL)로 구현
- 추후 인메모리 DB로 구현 변경 요망

close #142